### PR TITLE
[CLEANUP] Drop a 11.4-specific entry from the `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,6 @@
 		"typo3/cms": {
 			"app-dir": ".Build",
 			"extension-key": "tea",
-			"ignore-as-root": false,
 			"web-dir": ".Build/public"
 		}
 	},


### PR DESCRIPTION
`ignore-as-root` was needed in TYPO3 11.4 only and is obsolete with
11.5.