### PR TITLE
[FEATURE] Add command controller to create test data

### DIFF
--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -34,6 +34,7 @@ final class CreateTestDataCommand extends Command
             'sys_language_uid' => 0,
         ],
     ];
+
     protected function configure(): void
     {
         $this

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace TTN\Tea\Command;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Backend\Command\ProgressListener\ReferenceIndexProgressListener;
+use TYPO3\CMS\Backend\Command\ReferenceIndexUpdateCommand;
+use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\ReferenceIndex;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /*
@@ -75,6 +81,10 @@ final class CreateTestDataCommand extends Command
             );
         }
         $output->writeln(sprintf('Test data in page %s created.', $pageUid));
+
+        $referenceIndex = GeneralUtility::makeInstance(ReferenceIndex::class);
+        $referenceIndex->updateIndex(0);
+        $output->writeln('Reference index updated.');
 
         return Command::SUCCESS;
     }

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -4,16 +4,11 @@ declare(strict_types=1);
 
 namespace TTN\Tea\Command;
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
-use TYPO3\CMS\Backend\Command\ProgressListener\ReferenceIndexProgressListener;
-use TYPO3\CMS\Backend\Command\ReferenceIndexUpdateCommand;
-use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\ReferenceIndex;

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -19,7 +19,9 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class CreateTestDataCommand extends Command
 {
-    /** @phpstan-ignore-next-line */
+    /**
+     * @var list<array{title: non-empty-string, description: non-empty-string, sys_language_uid: int<0, max>}>
+     */
     protected array $teaData = [
         [
             'title' => 'Darjeeling',

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -54,8 +54,7 @@ final class CreateTestDataCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $pageUid = $input->getArgument('pageUid') ?? 0;
-        \assert(\is_int($pageUid));
+        $pageUid = (int)$input->getArgument('pageUid') ?? 0;
         $deleteDataBefore = $input->getOption('delete-data-before') ?? false;
         \assert(\is_bool($deleteDataBefore));
         $table = 'tx_tea_domain_model_tea';

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -54,7 +54,8 @@ final class CreateTestDataCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $pageUid = (int)$input->getArgument('pageUid') ?? 0;
+        $pageUid = $input->getArgument('pageUid') ?? 0;
+        \assert(\is_int($pageUid));
         $deleteDataBefore = $input->getOption('delete-data-before') ?? false;
         \assert(\is_bool($deleteDataBefore));
         $table = 'tx_tea_domain_model_tea';

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -70,12 +70,9 @@ final class CreateTestDataCommand extends Command
         $query = $connectionForTable;
         foreach ($this->teaData as $item) {
             $item = ['pid' => $pageUid, 'title' => $item['title'], 'description' => $item['description']];
-            $query->insert(
-                $table,
-                $item
-            );
+            $query->insert($table, $item);
         }
-        $output->writeln(sprintf('Test data in page %s created.', $pageUid));
+        $output->writeln(\sprintf('Test data in page %s created.', $pageUid));
 
         $referenceIndex = GeneralUtility::makeInstance(ReferenceIndex::class);
         $referenceIndex->updateIndex(false);

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -8,7 +8,6 @@ namespace TTN\Tea\Command;
  * Command to create test data for the tea extension.
  */
 
-use phpDocumentor\Reflection\Types\Integer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -39,7 +39,7 @@ final class CreateTestDataCommand extends Command
         $this
             ->setHelp('Create test data for the tea extension in an already existing page (sysfolder).')
             ->addArgument(
-                'pageId',
+                'pageUid',
                 InputArgument::REQUIRED,
                 'Existing sysfolder page id.'
             )
@@ -53,8 +53,8 @@ final class CreateTestDataCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var int $pageId */
-        $pageId = $input->getArgument('pageId') ?? 0;
+        /** @var int $pageUid */
+        $pageUid = $input->getArgument('pageUid') ?? 0;
         /** @var bool $deleteDataBefore */
         $deleteDataBefore = $input->getOption('delete-data-before') ?? false;
         $table = 'tx_tea_domain_model_tea';
@@ -62,19 +62,19 @@ final class CreateTestDataCommand extends Command
 
         if ($deleteDataBefore) {
             $query = $connectionForTable;
-            $query->delete($table, ['pid' => $pageId], [Connection::PARAM_INT]);
-            $output->writeln(sprintf('Existing data in page %s deleted.', $pageId));
+            $query->delete($table, ['pid' => $pageUid], [Connection::PARAM_INT]);
+            $output->writeln(sprintf('Existing data in page %s deleted.', $pageUid));
         }
 
         $query = $connectionForTable;
         foreach ($this->teaData as $item) {
-            $item = ['pid' => $pageId, ...$item];
+            $item = ['pid' => $pageUid, ...$item];
             $query->insert(
                 $table,
                 $item
             );
         }
-        $output->writeln(sprintf('Test data in page %s created.', $pageId));
+        $output->writeln(sprintf('Test data in page %s created.', $pageUid));
 
         return Command::SUCCESS;
     }

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -28,7 +28,7 @@ final class CreateTestDataCommand extends Command
             'description' => 'I love that tea!',
             'sys_language_uid' => 0,
         ],
-         [
+        [
             'title' => 'Earl Grey',
             'description' => 'A nice tea!',
             'sys_language_uid' => 0,
@@ -54,7 +54,8 @@ final class CreateTestDataCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $pageUid = (int)$input->getArgument('pageUid') ?? 0;
+        $pageUid = $input->getArgument('pageUid') ?? 0;
+        \assert(\is_int($pageUid));
         $deleteDataBefore = $input->getOption('delete-data-before') ?? false;
         \assert(\is_bool($deleteDataBefore));
         $table = 'tx_tea_domain_model_tea';
@@ -77,7 +78,7 @@ final class CreateTestDataCommand extends Command
         $output->writeln(sprintf('Test data in page %s created.', $pageUid));
 
         $referenceIndex = GeneralUtility::makeInstance(ReferenceIndex::class);
-        $referenceIndex->updateIndex(0);
+        $referenceIndex->updateIndex(false);
         $output->writeln('Reference index updated.');
 
         return Command::SUCCESS;

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -24,13 +24,13 @@ final class CreateTestDataCommand extends Command
         [
             'title' => 'Darjeeling',
             'description' => 'I love that tea!',
-            'sys_language_uid' => 0
+            'sys_language_uid' => 0,
         ],
          [
             'title' => 'Earl Grey',
             'description' => 'A nice tea!',
-            'sys_language_uid' => 0
-        ]
+            'sys_language_uid' => 0,
+        ],
     ];
     protected function configure(): void
     {
@@ -51,23 +51,24 @@ final class CreateTestDataCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var integer $pageId */
+        /** @var int $pageId */
         $pageId = $input->getArgument('pageId') ?? 0;
-        /** @var boolean $deleteDataBefore */
+        /** @var bool $deleteDataBefore */
         $deleteDataBefore = $input->getOption('delete-data-before') ?? false;
         $table = 'tx_tea_domain_model_tea';
         $connectionForTable = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($table);
 
-        if($deleteDataBefore) {
+        if ($deleteDataBefore) {
             $query = $connectionForTable;
             $query->delete($table, ['pid' => $pageId], [Connection::PARAM_INT]);
-            $output->writeln(sprintf('Existing data in page %s deleted.',$pageId));
+            $output->writeln(sprintf('Existing data in page %s deleted.', $pageId));
         }
 
         $query = $connectionForTable;
         foreach ($this->teaData as $item) {
             $item = ['pid' => $pageId, ...$item];
-            $query->insert($table,
+            $query->insert(
+                $table,
                 $item
             );
         }

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -69,7 +69,7 @@ final class CreateTestDataCommand extends Command
 
         $query = $connectionForTable;
         foreach ($this->teaData as $item) {
-            $item = ['pid' => $pageUid, ...$item];
+            $item = ['pid' => $pageUid, 'title' => $item['title'], 'description' => $item['description']];
             $query->insert(
                 $table,
                 $item

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -53,10 +53,10 @@ final class CreateTestDataCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var int $pageUid */
-        $pageUid = $input->getArgument('pageUid') ?? 0;
-        /** @var bool $deleteDataBefore */
+        $pageUid = (int)$input->getArgument('pageUid') ?? 0;
+        \assert(\is_int($pageUid));
         $deleteDataBefore = $input->getOption('delete-data-before') ?? false;
+        \assert(\is_bool($deleteDataBefore));
         $table = 'tx_tea_domain_model_tea';
         $connectionForTable = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($table);
 

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TTN\Tea\Command;
+
+/*
+ * Command to create test data for the tea extension.
+ */
+
+use phpDocumentor\Reflection\Types\Integer;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+final class CreateTestDataCommand extends Command
+{
+    /** @phpstan-ignore-next-line */
+    protected array $teaData = [
+        [
+            'title' => 'Darjeeling',
+            'description' => 'I love that tea!',
+            'sys_language_uid' => 0
+        ],
+         [
+            'title' => 'Earl Grey',
+            'description' => 'A nice tea!',
+            'sys_language_uid' => 0
+        ]
+    ];
+    protected function configure(): void
+    {
+        $this
+            ->setHelp('Create test data for the tea extension in an already existing page (sysfolder).')
+            ->addArgument(
+                'pageId',
+                InputArgument::REQUIRED,
+                'Existing sysfolder page id.'
+            )
+            ->addOption(
+                'delete-data-before',
+                'd',
+                InputOption::VALUE_NONE,
+                'Delete all tea data in the defined pid before creating new data.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var integer $pageId */
+        $pageId = $input->getArgument('pageId') ?? 0;
+        /** @var boolean $deleteDataBefore */
+        $deleteDataBefore = $input->getOption('delete-data-before') ?? false;
+        $table = 'tx_tea_domain_model_tea';
+        $connectionForTable = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($table);
+
+        if($deleteDataBefore) {
+            $query = $connectionForTable;
+            $query->delete($table, ['pid' => $pageId], [Connection::PARAM_INT]);
+            $output->writeln(sprintf('Existing data in page %s deleted.',$pageId));
+        }
+
+        $query = $connectionForTable;
+        foreach ($this->teaData as $item) {
+            $item = ['pid' => $pageId, ...$item];
+            $query->insert($table,
+                $item
+            );
+        }
+        $output->writeln(sprintf('Test data in page %s created.', $pageId));
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace TTN\Tea\Command;
 
-/*
- * Command to create test data for the tea extension.
- */
-
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,6 +13,9 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+/*
+ * Command to create test data for the tea extension.
+ */
 final class CreateTestDataCommand extends Command
 {
     /**

--- a/Classes/Command/CreateTestDataCommand.php
+++ b/Classes/Command/CreateTestDataCommand.php
@@ -60,7 +60,6 @@ final class CreateTestDataCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $pageUid = (int)$input->getArgument('pageUid') ?? 0;
-        \assert(\is_int($pageUid));
         $deleteDataBefore = $input->getOption('delete-data-before') ?? false;
         \assert(\is_bool($deleteDataBefore));
         $table = 'tx_tea_domain_model_tea';

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -19,7 +19,7 @@ return static function (ContainerConfigurator $containerConfigurator) {
         ->tag(
             'console.command',
             [
-                'command' => 'tea:createtestdata',
+                'command' => 'tea:create-test-data',
                 'description' => 'Create test data in existing sysfolder',
             ]
         );

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -16,10 +16,11 @@ return static function (ContainerConfigurator $containerConfigurator) {
         ->exclude('../Classes/Domain/Model/*');
 
     $services->set(CreateTestDataCommand::class)
-        ->tag('console.command', [
+        ->tag(
+            'console.command',
+            [
                 'command' => 'tea:createtestdata',
-                'description'=>'Create test data in existing sysfolder'
+                'description' => 'Create test data in existing sysfolder',
             ]
         );
-
 };

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use TTN\Tea\Command\CreateTestDataCommand;
+
 return static function (ContainerConfigurator $containerConfigurator) {
     $services = $containerConfigurator->services()
         ->defaults()
@@ -12,4 +14,12 @@ return static function (ContainerConfigurator $containerConfigurator) {
 
     $services->load('TTN\\Tea\\', '../Classes/*')
         ->exclude('../Classes/Domain/Model/*');
+
+    $services->set(CreateTestDataCommand::class)
+        ->tag('console.command', [
+                'command' => 'tea:createtestdata',
+                'description'=>'Create test data in existing sysfolder'
+            ]
+        );
+
 };

--- a/Documentation/CommandController.rst
+++ b/Documentation/CommandController.rst
@@ -18,7 +18,7 @@ You can add option `-d` to delete already existing data.
 
 .. code-block:: bash
 
-   vendor/bin/typo3 tea:createtestdata 3
+   vendor/bin/typo3 tea:create-test-data 3
 
 
 .. seealso::

--- a/Documentation/CommandController.rst
+++ b/Documentation/CommandController.rst
@@ -1,0 +1,28 @@
+.. include:: /Includes.rst.txt
+
+.. _command-controller:
+
+==================
+Command Controller
+==================
+
+The "tea" extension comes with a CommandController that can be used for the
+automatic creation of test data. It also serves to illustrate how data can be
+created in the database using a command controller.
+
+You must set a page id as argument. Therefore it's necessary to create an
+sysfolder before.
+
+You can add option `-d` to delete already existing data.
+
+
+.. code-block:: bash
+
+   vendor/bin/typo3 tea:createtestdata 3
+
+
+.. seealso::
+
+   For further details to Console Commands read the
+   :ref:`Creating a basic command <t3coreapi:console-command-tutorial-create>`
+   tutorial.

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -47,6 +47,7 @@ continuous integration.
    ReleaseBranchingStrategy
    Environment
    DependencyManager
+   CommandController
    Running
    ContinuousIntegration
    Documentation

--- a/Tests/Functional/Command/CreateTestDataCommandTest.php
+++ b/Tests/Functional/Command/CreateTestDataCommandTest.php
@@ -68,7 +68,7 @@ class CreateTestDataCommandTest extends FunctionalTestCase
     {
         $result = $this->commandTester->execute(
             [
-                'pageUid' => '1',
+                'pageUid' => 1,
             ],
         );
 
@@ -81,7 +81,7 @@ class CreateTestDataCommandTest extends FunctionalTestCase
     public function createsTestData(): void
     {
         $this->commandTester->execute([
-            'pageUid' => '1',
+            'pageUid' => 1,
         ]);
 
         self::assertCSVDataSet(__DIR__ . '/Fixtures/Database/Teas.csv');
@@ -95,7 +95,7 @@ class CreateTestDataCommandTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/ExistingTeas.csv');
         $this->commandTester->execute(
             [
-                'pageUid' => '1',
+                'pageUid' => 1,
                 '--delete-data-before' => true,
             ]
         );
@@ -111,7 +111,7 @@ class CreateTestDataCommandTest extends FunctionalTestCase
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/OtherExistingTeas.csv');
         $this->commandTester->execute(
             [
-                'pageUid' => '1',
+                'pageUid' => 1,
                 '--delete-data-before' => true,
             ]
         );

--- a/Tests/Functional/Command/CreateTestDataCommandTest.php
+++ b/Tests/Functional/Command/CreateTestDataCommandTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TTN\Tea\Tests\Functional\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TTN\Tea\Command\CreateTestDataCommand;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * @covers \TTN\Tea\Command\CreateTestDataCommand
+ */
+class CreateTestDataCommandTest extends FunctionalTestCase
+{
+    private const COMMAND_NAME = 'tea:createtestdata';
+
+    protected array $testExtensionsToLoad = ['ttn/tea'];
+
+    private CreateTestDataCommand $subject;
+
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/Pages.csv');
+        $this->subject = new CreateTestDataCommand(self::COMMAND_NAME);
+        $application = new Application();
+        $application->add($this->subject);
+
+        $command = $application->find('tea:createtestdata');
+        $this->commandTester = new CommandTester($command);
+    }
+
+    /**
+     * @test
+     */
+    public function isConsoleCommand(): void
+    {
+        self::assertInstanceOf(Command::class, $this->subject);
+    }
+
+    /**
+     * @test
+     */
+    public function hasDescription(): void
+    {
+        $expected = 'Create test data for the tea extension in an already existing page (sysfolder).';
+        self::assertSame($expected, $this->subject->getHelp());
+    }
+
+    /**
+     * @test
+     */
+    public function hasHelpText(): void
+    {
+        $expected = 'Create test data for the tea extension in an already existing page (sysfolder).';
+        self::assertSame($expected, $this->subject->getHelp());
+    }
+
+    /**
+     * @test
+     */
+    public function runReturnsSuccessStatus(): void
+    {
+        $result = $this->commandTester->execute(
+            [
+                'pageUid' => '1',
+            ],
+        );
+
+        self::assertSame(Command::SUCCESS, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function testDataGetsCreated(): void
+    {
+        $this->commandTester->execute([
+            'pageUid' => '1',
+        ]);
+
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Database/Teas.csv');
+    }
+
+    /**
+     * @test
+     */
+    public function testDataGetsDeletedBeforeNewDataCreated(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/Teas.csv');
+        $this->commandTester->execute(
+            [
+                'pageUid' => '1',
+                '--delete-data-before' => true,
+            ]
+        );
+
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAfterDelete.csv');
+    }
+
+}

--- a/Tests/Functional/Command/CreateTestDataCommandTest.php
+++ b/Tests/Functional/Command/CreateTestDataCommandTest.php
@@ -92,7 +92,7 @@ class CreateTestDataCommandTest extends FunctionalTestCase
      */
     public function testDataGetsDeletedBeforeNewDataCreated(): void
     {
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/Teas.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/ExistingTeas.csv');
         $this->commandTester->execute(
             [
                 'pageUid' => '1',

--- a/Tests/Functional/Command/CreateTestDataCommandTest.php
+++ b/Tests/Functional/Command/CreateTestDataCommandTest.php
@@ -13,8 +13,11 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 /**
  * @covers \TTN\Tea\Command\CreateTestDataCommand
  */
-class CreateTestDataCommandTest extends FunctionalTestCase
+final class CreateTestDataCommandTest extends FunctionalTestCase
 {
+    /**
+     * @var non-empty-string
+     */
     private const COMMAND_NAME = 'tea:create-test-data';
 
     protected array $testExtensionsToLoad = ['ttn/tea'];
@@ -84,7 +87,7 @@ class CreateTestDataCommandTest extends FunctionalTestCase
             'pageUid' => 1,
         ]);
 
-        self::assertCSVDataSet(__DIR__ . '/Fixtures/Database/Teas.csv');
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/Database/Teas.csv');
     }
 
     /**
@@ -100,7 +103,7 @@ class CreateTestDataCommandTest extends FunctionalTestCase
             ]
         );
 
-        self::assertCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAfterDelete.csv');
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAfterDelete.csv');
     }
 
     /**
@@ -116,6 +119,6 @@ class CreateTestDataCommandTest extends FunctionalTestCase
             ]
         );
 
-        self::assertCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAfterDeleteOtherExistingTeas.csv');
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAfterDeleteOtherExistingTeas.csv');
     }
 }

--- a/Tests/Functional/Command/CreateTestDataCommandTest.php
+++ b/Tests/Functional/Command/CreateTestDataCommandTest.php
@@ -78,7 +78,7 @@ class CreateTestDataCommandTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function testDataGetsCreated(): void
+    public function createsTestData(): void
     {
         $this->commandTester->execute([
             'pageUid' => '1',
@@ -90,7 +90,7 @@ class CreateTestDataCommandTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function testDataGetsDeletedBeforeNewDataCreated(): void
+    public function deletesExistingDataOnGivenPidBeforeCreatingNewData(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/ExistingTeas.csv');
         $this->commandTester->execute(
@@ -106,7 +106,7 @@ class CreateTestDataCommandTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function existingDataWillBeNotDeleted(): void
+    public function doesNotDeleteDataOnOtherPid(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/OtherExistingTeas.csv');
         $this->commandTester->execute(
@@ -115,7 +115,7 @@ class CreateTestDataCommandTest extends FunctionalTestCase
                 '--delete-data-before' => true,
             ]
         );
+
         self::assertCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAfterDeleteOtherExistingTeas.csv');
     }
-
 }

--- a/Tests/Functional/Command/CreateTestDataCommandTest.php
+++ b/Tests/Functional/Command/CreateTestDataCommandTest.php
@@ -15,7 +15,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  */
 class CreateTestDataCommandTest extends FunctionalTestCase
 {
-    private const COMMAND_NAME = 'tea:createtestdata';
+    private const COMMAND_NAME = 'tea:create-test-data';
 
     protected array $testExtensionsToLoad = ['ttn/tea'];
 
@@ -31,7 +31,7 @@ class CreateTestDataCommandTest extends FunctionalTestCase
         $application = new Application();
         $application->add($this->subject);
 
-        $command = $application->find('tea:createtestdata');
+        $command = $application->find('tea:create-test-data');
         $this->commandTester = new CommandTester($command);
     }
 

--- a/Tests/Functional/Command/CreateTestDataCommandTest.php
+++ b/Tests/Functional/Command/CreateTestDataCommandTest.php
@@ -103,4 +103,19 @@ class CreateTestDataCommandTest extends FunctionalTestCase
         self::assertCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAfterDelete.csv');
     }
 
+    /**
+     * @test
+     */
+    public function existingDataWillBeNotDeleted(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/OtherExistingTeas.csv');
+        $this->commandTester->execute(
+            [
+                'pageUid' => '1',
+                '--delete-data-before' => true,
+            ]
+        );
+        self::assertCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAfterDeleteOtherExistingTeas.csv');
+    }
+
 }

--- a/Tests/Functional/Command/Fixtures/Database/ExistingTeas.csv
+++ b/Tests/Functional/Command/Fixtures/Database/ExistingTeas.csv
@@ -1,0 +1,4 @@
+"tx_tea_domain_model_tea"
+,"uid","pid","title","description","deleted"
+,1,1,"Darjeeling","Which already existed in the system",0
+,2,1,"Earl Grey","Which already existed in the system",0

--- a/Tests/Functional/Command/Fixtures/Database/OtherExistingTeas.csv
+++ b/Tests/Functional/Command/Fixtures/Database/OtherExistingTeas.csv
@@ -1,0 +1,6 @@
+"tx_tea_domain_model_tea"
+,"uid","pid","title","description","deleted"
+,3,1,"Darjeeling","Exists and should be deleted","0"
+,4,1,"Earl Grey","Exists and should be deleted","0"
+,1,2,"Darjeeling","Which already existed in the system",0
+,2,2,"Earl Grey","Which already existed in the system",0

--- a/Tests/Functional/Command/Fixtures/Database/OtherTeas.csv
+++ b/Tests/Functional/Command/Fixtures/Database/OtherTeas.csv
@@ -1,6 +1,0 @@
-"tx_tea_domain_model_tea"
-,"uid","pid","title","description","deleted"
-,3,1,"Darjeeling","I love that tea!","0"
-,4,1,"Earl Grey","A nice tea!","0"
-,1,2,"Black tea","I hate that.","0"
-,2,2,"Green tea","Is ok.","0"

--- a/Tests/Functional/Command/Fixtures/Database/OtherTeas.csv
+++ b/Tests/Functional/Command/Fixtures/Database/OtherTeas.csv
@@ -1,0 +1,6 @@
+"tx_tea_domain_model_tea"
+,"uid","pid","title","description","deleted"
+,3,1,"Darjeeling","I love that tea!","0"
+,4,1,"Earl Grey","A nice tea!","0"
+,1,2,"Black tea","I hate that.","0"
+,2,2,"Green tea","Is ok.","0"

--- a/Tests/Functional/Command/Fixtures/Database/Pages.csv
+++ b/Tests/Functional/Command/Fixtures/Database/Pages.csv
@@ -1,0 +1,4 @@
+"pages",,,,,,,,,
+,"uid","pid","sorting","deleted","t3_origuid","title",,,
+,1,0,256,0,0,"Tea data",,,
+,2,0,512,0,0,"Other tea data",,,

--- a/Tests/Functional/Command/Fixtures/Database/Teas.csv
+++ b/Tests/Functional/Command/Fixtures/Database/Teas.csv
@@ -1,0 +1,4 @@
+"tx_tea_domain_model_tea"
+,"uid","pid","title","description","deleted"
+,1,1,"Darjeeling","I love that tea!",0
+,2,1,"Earl Grey","A nice tea!",0

--- a/Tests/Functional/Command/Fixtures/Database/TeasAfterDelete.csv
+++ b/Tests/Functional/Command/Fixtures/Database/TeasAfterDelete.csv
@@ -1,4 +1,4 @@
 "tx_tea_domain_model_tea"
-,"uid","pid","title","description","deleted"
-,3,1,"Darjeeling","I love that tea!",0
-,4,1,"Earl Grey","A nice tea!",0
+,"pid","title","description","deleted"
+,1,"Darjeeling","I love that tea!",0
+,1,"Earl Grey","A nice tea!",0

--- a/Tests/Functional/Command/Fixtures/Database/TeasAfterDelete.csv
+++ b/Tests/Functional/Command/Fixtures/Database/TeasAfterDelete.csv
@@ -1,0 +1,4 @@
+"tx_tea_domain_model_tea"
+,"uid","pid","title","description","deleted"
+,3,1,"Darjeeling","I love that tea!",0
+,4,1,"Earl Grey","A nice tea!",0

--- a/Tests/Functional/Command/Fixtures/Database/TeasAfterDeleteOtherExistingTeas.csv
+++ b/Tests/Functional/Command/Fixtures/Database/TeasAfterDeleteOtherExistingTeas.csv
@@ -1,0 +1,6 @@
+"tx_tea_domain_model_tea"
+,"pid","title","description","deleted"
+,1,"Darjeeling","I love that tea!",0
+,1,"Earl Grey","A nice tea!",0
+,2,"Darjeeling","Which already existed in the system",0
+,2,"Earl Grey","Which already existed in the system",0

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -53,3 +53,7 @@ parameters:
         - '$_FILES'
         - '$_SERVER'
       message: 'Use PSR-7 API instead'
+  ignoreErrors:
+    -
+      message: '#Out of 1 possible constant types#'
+      path: Tests/Functional/Command/CreateTestDataCommandTest.php


### PR DESCRIPTION
Simple command to add test data for tea model with a console command. It's just the first try and should be extended by more data, translations, etc.

Resolves: #1120