### PR TITLE
[BUGFIX] Make PHP-CS-Fixer >= 3.66 compatible with PHPUnit 9.x

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -4,6 +4,14 @@ use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 use TYPO3\CodingStandards\CsFixerConfig;
 
 $config = CsFixerConfig::create();
+// This is required as long as we are on PHPUnit 9.x. It can be removed after the switch to PHPUnit 10.x.
+// @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8337
+$config->setRules(
+    [
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self', 'methods' => ['createStub' => 'this']],
+    ]
+);
+
 // @TODO 4.0 no need to call this manually
 $config->setParallelConfig(ParallelConfigFactory::detect());
 $config->getFinder()->in('Classes')->in('Configuration')->in('Tests');


### PR DESCRIPTION
@see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8337