### PR TITLE
[TASK] Improve readability of php-cs-fixer configuration

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -5,11 +5,11 @@ use TYPO3\CodingStandards\CsFixerConfig;
 
 $config = CsFixerConfig::create();
 
-// This is required as long as we are on PHPUnit 9.x. It can be removed after the switch to PHPUnit 10.x.
-// @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8337
-$rules = $config->getRules();
-$rules['php_unit_test_case_static_method_calls'] = ['call_type' => 'self', 'methods' => ['createStub' => 'this']];
-$config->setRules($rules);
+$config->addRules([
+    // This is required as long as we are on PHPUnit 9.x. It can be removed after the switch to PHPUnit 10.x.
+    // @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8337
+    'php_unit_test_case_static_method_calls' => ['call_type' => 'self', 'methods' => ['createStub' => 'this']],
+]);
 
 // @TODO 4.0 no need to call this manually
 $config->setParallelConfig(ParallelConfigFactory::detect());


### PR DESCRIPTION
We now use `addRules()` method instead of fiddling around with an array of rules.
It allows us to overwrite existing rules, or even disable existing rules by setting them to `false`.