### PR TITLE
[BUGFIX] Improve type safety for lazy-loaded associations

### DIFF
--- a/Classes/Domain/Model/Tea.php
+++ b/Classes/Domain/Model/Tea.php
@@ -52,9 +52,8 @@ class Tea extends AbstractEntity
     public function getImage(): ?FileReference
     {
         if ($this->image instanceof LazyLoadingProxy) {
-            /** @var FileReference $image */
             $image = $this->image->_loadRealInstance();
-            $this->image = $image;
+            $this->image = ($image instanceof FileReference) ? $image : null;
         }
 
         return $this->image;

--- a/Tests/Functional/Domain/Repository/Fixtures/propertyMapping/TeaWithDeletedImage.csv
+++ b/Tests/Functional/Domain/Repository/Fixtures/propertyMapping/TeaWithDeletedImage.csv
@@ -1,0 +1,3 @@
+"tx_tea_domain_model_tea"
+,"uid","title","image",
+,1,"Gunpowder",1

--- a/Tests/Functional/Domain/Repository/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/TeaRepositoryTest.php
@@ -118,6 +118,19 @@ final class TeaRepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function MapsDeletedImageRelationToNull(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/propertyMapping/TeaWithDeletedImage.csv');
+
+        $model = $this->subject->findByUid(1);
+        self::assertInstanceOf(Tea::class, $model);
+
+        self::assertNull($model->getImage());
+    }
+
+    /**
+     * @test
+     */
     public function addAndPersistAllCreatesNewRecord(): void
     {
         $title = 'Godesberger Burgtee';


### PR DESCRIPTION
`_loadRealInstance` will return `null` if the target of the association does not exist (anymore). We need to handle that case in a clean way.

Also use a dedicated folder for the fixture to make the fixture easier to find, and to discourage reuse of fixtures.