### PR TITLE
[FEATURE] Add `rector/type-perfect` PHPStan rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
 		"phpstan/phpstan-phpunit": "1.4.2",
 		"phpstan/phpstan-strict-rules": "1.6.1",
 		"phpunit/phpunit": "9.6.22",
+		"rector/type-perfect": "1.0.0",
 		"saschaegerer/phpstan-typo3": "1.10.2",
 		"seld/jsonlint": "1.11.0",
 		"spaze/phpstan-disallowed-calls": "4.3.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,6 +30,13 @@ parameters:
     class: 10
     function: 5
 
+  type_perfect:
+    no_mixed_property: true
+    no_mixed_caller: true
+    null_over_false: true
+    narrow_param: true
+    narrow_return: true
+
   disallowedFunctionCalls:
     -
       function:
@@ -40,12 +47,14 @@ parameters:
     -
       function: 'header()'
       message: 'Use PSR-7 API instead'
+
   disallowedStaticCalls:
     -
       method:
         - 'TYPO3\CMS\Extbase\Utility\DebuggerUtility::var_dump()'
         - 'TYPO3\CMS\Core\Utility\DebugUtility::debug()'
       message: 'Use logging instead or remove if it was for debugging purposes.'
+
   disallowedSuperglobals:
     -
       superglobal:
@@ -54,6 +63,7 @@ parameters:
         - '$_FILES'
         - '$_SERVER'
       message: 'Use PSR-7 API instead'
+
   ignoreErrors:
     -
       message: '#Out of 1 possible constant types#'


### PR DESCRIPTION
This package provides some opiniated PHPStan rules to make our code more explicit and easier to read.

https://github.com/rectorphp/type-perfect

As our code already is in pretty good shape, the new rules do not create any new warnings.

Also add some blank lines to the PHPStan configuration file to make it more readable.

Fixes #1335