### PR TITLE
[FEATURE] Test the `prepare-release` Composer script on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,30 @@ jobs:
           - "xliff:lint"
         php-version:
           - "8.3"
+  prepare-release:
+    name: "Check prepare release script"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+      - name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php-version }}"
+          ini-file: development
+          coverage: none
+          tools: composer:v2
+      - name: "Show Composer version"
+        run: "composer --version"
+      - name: "Show the Composer configuration"
+        run: "composer config --global --list"
+      - name: "Run command"
+        run: "composer prepare-release"
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "8.3"
   code-quality-frontend:
     name: "Code quality frontend checks"
     runs-on: ubuntu-24.04

--- a/.gitlab/pipeline/.gitlab-ci.yml
+++ b/.gitlab/pipeline/.gitlab-ci.yml
@@ -29,6 +29,7 @@ include:
   - '/.gitlab/pipeline/jobs/php-lint-php8.2.yml'
   - '/.gitlab/pipeline/jobs/php-lint-php8.3.yml'
   - '/.gitlab/pipeline/jobs/php-lint-php8.4.yml'
+  - '/.gitlab/pipeline/jobs/prepare-release.yml'
   - '/.gitlab/pipeline/jobs/rector.yml'
   - '/.gitlab/pipeline/jobs/typoscript-lint.yml'
   - '/.gitlab/pipeline/jobs/unit-v12-php8.1-highest.yml'

--- a/.gitlab/pipeline/jobs/prepare-release.yml
+++ b/.gitlab/pipeline/jobs/prepare-release.yml
@@ -1,0 +1,5 @@
+prepare-release:
+  extends: .default
+  stage: test
+  script:
+    - composer prepare-release


### PR DESCRIPTION
This script tends to break when we move configuration files around. To prevent this in the future, we now check this script on CI.