### PR TITLE
[BUGFIX] GitLab CI Pipeline

### DIFF
--- a/.gitlab/pipeline/jobs/.default.yml
+++ b/.gitlab/pipeline/jobs/.default.yml
@@ -2,7 +2,5 @@
   image: ghcr.io/typo3/core-testing-php83:latest
   before_script:
     - bash .gitlab/build/docker_install.sh > /dev/null
-  variables:
-    PHP_INI_SCAN_DIR: "/etc/php"
   script:
-  - cp $CI_PROJECT_DIR/.gitlab/pipeline/ci/php.ini /usr/local/etc/php/php.ini; # copy php.ini into image
+  - cp $CI_PROJECT_DIR/.gitlab/pipeline/ci/php.ini /usr/local/etc/php/conf.d/z_php.ini; # copy php.ini into image


### PR DESCRIPTION
The CI didn't had the PHP intl extension enabled.
We now use the existing `php.ini` also within the GitLab CI. This already enabled the already installed extension, and therefore allows to install the composer dependencies and pass the CI.

Resolves: #1354, #1636