### PR TITLE
[FEATURE] Add proper 404 handling for tea detail action

### DIFF
--- a/Classes/Controller/TeaController.php
+++ b/Classes/Controller/TeaController.php
@@ -27,6 +27,9 @@ class TeaController extends ActionController
         return $this->htmlResponse();
     }
 
+    /**
+     * @throws PropagateResponseException
+     */
     public function showAction(?Tea $tea = null): ResponseInterface
     {
         if ($tea === null) {
@@ -39,6 +42,8 @@ class TeaController extends ActionController
 
     /**
      * Will throw exception to trigger 404.
+     *
+     * @throws PropagateResponseException
      *
      * @return never
      */

--- a/Classes/Controller/TeaController.php
+++ b/Classes/Controller/TeaController.php
@@ -7,7 +7,9 @@ namespace TTN\Tea\Controller;
 use Psr\Http\Message\ResponseInterface;
 use TTN\Tea\Domain\Model\Tea;
 use TTN\Tea\Domain\Repository\TeaRepository;
+use TYPO3\CMS\Core\Http\PropagateResponseException;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Frontend\Controller\ErrorController;
 
 /**
  * Controller for the main "Tea" FE plugin.
@@ -16,6 +18,7 @@ class TeaController extends ActionController
 {
     public function __construct(
         private readonly TeaRepository $teaRepository,
+        private readonly ErrorController $errorController,
     ) {}
 
     public function indexAction(): ResponseInterface
@@ -24,9 +27,26 @@ class TeaController extends ActionController
         return $this->htmlResponse();
     }
 
-    public function showAction(Tea $tea): ResponseInterface
+    public function showAction(?Tea $tea = null): ResponseInterface
     {
+        if ($tea === null) {
+            $this->trigger404('No tea given.');
+        }
+
         $this->view->assign('tea', $tea);
         return $this->htmlResponse();
+    }
+
+    /**
+     * Will throw exception to trigger 404.
+     *
+     * @return never
+     */
+    protected function trigger404(string $message): void
+    {
+        throw new PropagateResponseException(
+            $this->errorController->pageNotFoundAction($this->request, $message),
+            1744021673
+        );
     }
 }

--- a/Classes/Controller/TeaController.php
+++ b/Classes/Controller/TeaController.php
@@ -41,7 +41,7 @@ class TeaController extends ActionController
     }
 
     /**
-     * Will throw exception to trigger 404.
+     * @throws PropagateResponseException
      *
      * @throws PropagateResponseException
      *

--- a/Classes/Controller/TeaController.php
+++ b/Classes/Controller/TeaController.php
@@ -43,8 +43,6 @@ class TeaController extends ActionController
     /**
      * @throws PropagateResponseException
      *
-     * @throws PropagateResponseException
-     *
      * @return never
      */
     protected function trigger404(string $message): void

--- a/Tests/Functional/Controller/TeaControllerTest.php
+++ b/Tests/Functional/Controller/TeaControllerTest.php
@@ -129,7 +129,7 @@ final class TeaControllerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function showActionTriggering404ReasonIsRendered(): void
+    public function showActionFor404RendersReasonFor404(): void
     {
         $request = (new InternalRequest())->withPageId(3);
 

--- a/Tests/Functional/Controller/TeaControllerTest.php
+++ b/Tests/Functional/Controller/TeaControllerTest.php
@@ -101,4 +101,16 @@ final class TeaControllerTest extends FunctionalTestCase
         self::assertStringContainsString('Godesberger Burgtee', $html);
         self::assertStringNotContainsString('Oolong', $html);
     }
+
+    /**
+     * @test
+     */
+    public function showActionTriggers404ForMissingTea(): void
+    {
+        $request = (new InternalRequest())->withPageId(3)->withQueryParameters(['tx_tea_teashow[tea]' => 1]);
+
+        $response = $this->executeFrontendSubRequest($request);
+
+        self::assertSame(404, $response->getStatusCode());
+    }
 }

--- a/Tests/Functional/Controller/TeaControllerTest.php
+++ b/Tests/Functional/Controller/TeaControllerTest.php
@@ -105,12 +105,36 @@ final class TeaControllerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function showActionTriggers404ForMissingTea(): void
+    public function showActionTriggers404ForMissingTeaArgument(): void
+    {
+        $request = (new InternalRequest())->withPageId(3);
+
+        $response = $this->executeFrontendSubRequest($request);
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function showActionTriggers404ForUnavailableTea(): void
     {
         $request = (new InternalRequest())->withPageId(3)->withQueryParameters(['tx_tea_teashow[tea]' => 1]);
 
         $response = $this->executeFrontendSubRequest($request);
 
         self::assertSame(404, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function showActionTriggering404ReasonIsRendered(): void
+    {
+        $request = (new InternalRequest())->withPageId(3);
+
+        $html = (string)$this->executeFrontendSubRequest($request)->getBody();
+
+        self::assertStringContainsString('Reason: No tea given.', $html);
     }
 }

--- a/composer-unused.php
+++ b/composer-unused.php
@@ -7,6 +7,5 @@ use ComposerUnused\ComposerUnused\Configuration\NamedFilter;
 
 return static function (Configuration $config): Configuration {
     $config->addNamedFilter(NamedFilter::fromString('typo3/cms-fluid'));
-    $config->addNamedFilter(NamedFilter::fromString('typo3/cms-frontend'));
     return $config;
 };


### PR DESCRIPTION
Properly trigger TYPO3 404 handling in case a none available tea was requested.
That might happen when old links to no longer existing teas are called. Or if people play around with the URL.

We also cover this new feature with a functional test.

Related: #1565