### PR TITLE
[TASK] Shorten the GitHub Actions CI job label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ---
 # This GitHub Actions workflow uses the same development tools that are also installed locally
 # via Composer or PHIVE and calls them using the Composer scripts.
-name: CI with Composer scripts
+name: GitHub Actions CI
 on:
   push:
     branches:


### PR DESCRIPTION
This makes the badge in the README shorter. Also, it makes it easier to differentiate between the badge for GitHub Actions and the one for GitLab CI.