### PR TITLE
[TASK] Remove brianium/paratest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
       - dependency-type: "development"
     ignore:
       - dependency-name: "doctrine/dbal"
+      - dependency-name: "phpunit/phpunit"
+        versions: [ "^11.0" ]
       - dependency-name: "symfony/console"
       - dependency-name: "symfony/translation"
       - dependency-name: "symfony/yaml"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,7 @@ updates:
     allow:
       - dependency-type: "development"
     ignore:
-      - dependency-name: "brianium/paratest"
       - dependency-name: "doctrine/dbal"
-      - dependency-name: "phpunit/phpunit"
       - dependency-name: "symfony/console"
       - dependency-name: "symfony/translation"
       - dependency-name: "symfony/yaml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,10 +184,9 @@ jobs:
           - typo3-version: "^12.4"
             php-version: "8.1"
             composer-dependencies: lowest
-# disabled due to issues with ParaTest
-#          - typo3-version: "^12.4"
-#            php-version: "8.1"
-#            composer-dependencies: highest
+          - typo3-version: "^12.4"
+            php-version: "8.1"
+            composer-dependencies: highest
           - typo3-version: "^12.4"
             php-version: "8.2"
             composer-dependencies: lowest
@@ -268,10 +267,9 @@ jobs:
           - typo3-version: "^12.4"
             php-version: "8.1"
             composer-dependencies: lowest
-# disabled due to issues with ParaTest
-#          - typo3-version: "^12.4"
-#            php-version: "8.1"
-#            composer-dependencies: highest
+          - typo3-version: "^12.4"
+            php-version: "8.1"
+            composer-dependencies: highest
           - typo3-version: "^12.4"
             php-version: "8.2"
             composer-dependencies: lowest

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -555,7 +555,7 @@ case ${TEST_SUITE} in
         ;;
     functional)
         [ -z "${TEST_FILE}" ] && TEST_FILE="Tests/Functional"
-        COMMAND=".Build/bin/paratest -c Build/phpunit/FunctionalTests.xml --exclude-group not-${DBMS} ${EXTRA_TEST_OPTIONS} ${TEST_FILE}"
+        COMMAND=".Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml --exclude-group not-${DBMS} ${EXTRA_TEST_OPTIONS} ${TEST_FILE}"
         case ${DBMS} in
             mariadb)
                 echo "Using driver: ${DATABASE_DRIVER}"
@@ -642,12 +642,12 @@ case ${TEST_SUITE} in
         ;;
     unit)
         [ -z "${TEST_FILE}" ] && TEST_FILE="Tests/Unit"
-        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} .Build/bin/paratest -c Build/phpunit/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE}
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} .Build/bin/phpunit -c Build/phpunit/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE}
         SUITE_EXIT_CODE=$?
         ;;
     unitRandom)
         [ -z "${TEST_FILE}" ] && TEST_FILE="Tests/Unit"
-        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-random-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} .Build/bin/paratest -c Build/phpunit/UnitTests.xml --order-by=random ${EXTRA_TEST_OPTIONS} ${PHPUNIT_RANDOM} ${TEST_FILE}
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-random-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} .Build/bin/phpunit -c Build/phpunit/UnitTests.xml --order-by=random ${EXTRA_TEST_OPTIONS} ${PHPUNIT_RANDOM} ${TEST_FILE}
         SUITE_EXIT_CODE=$?
         ;;
     update)

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
 		"typo3/cms-frontend": "^12.4.26"
 	},
 	"require-dev": {
-		"brianium/paratest": "7.3.1 || 7.4.8",
 		"ergebnis/composer-normalize": "2.45.0",
 		"friendsofphp/php-cs-fixer": "3.75.0",
 		"helmich/typo3-typoscript-lint": "^3.3.0",
@@ -58,7 +57,7 @@
 		"phpstan/phpstan": "1.12.14",
 		"phpstan/phpstan-phpunit": "1.4.2",
 		"phpstan/phpstan-strict-rules": "1.6.1",
-		"phpunit/phpunit": "10.5.31 || 10.5.44",
+		"phpunit/phpunit": "^10.5",
 		"rector/type-perfect": "1.0.0",
 		"saschaegerer/phpstan-typo3": "1.10.2",
 		"seld/jsonlint": "1.11.0",
@@ -128,7 +127,7 @@
 		"ci:coverage:functional": [
 			"@ci:tests:create-directories",
 			"@coverage:create-directories",
-			"paratest -c Build/phpunit/FunctionalTests.xml --coverage-php=build/coverage/functional.cov Tests/Functional"
+			"phpunit -c Build/phpunit/FunctionalTests.xml --coverage-php=build/coverage/functional.cov Tests/Functional"
 		],
 		"ci:coverage:merge": [
 			"@coverage:create-directories",
@@ -136,7 +135,7 @@
 		],
 		"ci:coverage:unit": [
 			"@coverage:create-directories",
-			"paratest -c Build/phpunit/UnitTests.xml --coverage-php=build/coverage/unit.cov Tests/Unit"
+			"phpunit -c Build/phpunit/UnitTests.xml --coverage-php=build/coverage/unit.cov Tests/Unit"
 		],
 		"ci:json:lint": "find . ! -path '*/.cache/*' ! -path '*/.Build/*' ! -path '*/node_modules/*' -name '*.json' | xargs -r php .Build/bin/jsonlint -q",
 		"ci:php": [
@@ -164,9 +163,9 @@
 		"ci:tests:create-directories": "mkdir -p .Build/public/typo3temp/var/tests",
 		"ci:tests:functional": [
 			"@ci:tests:create-directories",
-			"paratest -c Build/phpunit/FunctionalTests.xml Tests/Functional"
+			"phpunit -c Build/phpunit/FunctionalTests.xml Tests/Functional"
 		],
-		"ci:tests:unit": "paratest -c Build/phpunit/UnitTests.xml Tests/Unit",
+		"ci:tests:unit": "phpunit -c Build/phpunit/UnitTests.xml Tests/Unit",
 		"ci:typoscript:lint": "typoscript-lint -c Configuration/TsLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript",
 		"ci:xliff:lint": "php Build/xliff/xliff-lint lint:xliff Resources/Private/Language",
 		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' \\( -name '*.yaml' -o -name '*.yml' \\) | xargs -r php ./.Build/bin/yaml-lint",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
 		"phpstan/phpstan": "1.12.14",
 		"phpstan/phpstan-phpunit": "1.4.2",
 		"phpstan/phpstan-strict-rules": "1.6.1",
-		"phpunit/phpunit": "^10.5",
+		"phpunit/phpunit": "10.5.45",
 		"rector/type-perfect": "1.0.0",
 		"saschaegerer/phpstan-typo3": "1.10.2",
 		"seld/jsonlint": "1.11.0",


### PR DESCRIPTION
As this component is not necessary in our setup yet. It is also easy to setup, so no need for us to showcase this.

Also this adds some extra complexity to our setup due to: https://github.com/paratestphp/paratest/issues/890 which was the trigger to remove the component.

Resolves: #1647