### PR TITLE
[TASK] Migrate existing Unit Tests to Functional Tests

### DIFF
--- a/Tests/Functional/Controller/Fixtures/Database/ContentElementTeaFrontEndEditor.csv
+++ b/Tests/Functional/Controller/Fixtures/Database/ContentElementTeaFrontEndEditor.csv
@@ -1,0 +1,3 @@
+"tt_content"
+,"uid","pid","CType","header","list_type"
+,1,1,"list","Tea FrontEnd Editor","tea_teafrontendeditor"

--- a/Tests/Functional/Controller/Fixtures/Database/Create/CreatedWithOwner.csv
+++ b/Tests/Functional/Controller/Fixtures/Database/Create/CreatedWithOwner.csv
@@ -1,0 +1,3 @@
+"tx_tea_domain_model_tea"
+,"uid","pid","title","owner"
+,1,2,"Darjeeling",1

--- a/Tests/Functional/Controller/Fixtures/Database/Delete/Deleted.csv
+++ b/Tests/Functional/Controller/Fixtures/Database/Delete/Deleted.csv
@@ -1,0 +1,5 @@
+"tx_tea_domain_model_tea"
+,"uid","pid","title","owner","deleted"
+,1,2,"Godesberger Burgtee",1,1
+,2,2,"Oolong",2,0
+,3,2,"Sencha",0,0

--- a/Tests/Functional/Controller/Fixtures/Database/FrontendUsers.csv
+++ b/Tests/Functional/Controller/Fixtures/Database/FrontendUsers.csv
@@ -1,0 +1,3 @@
+"fe_users"
+,"uid","pid","username","password"
+,1,2,"user_a","$1$tCrlLajZ$C0sikFQQ3SWaFAZ1Me0Z/1"

--- a/Tests/Functional/Controller/Fixtures/Database/TeasAssignedToUser.csv
+++ b/Tests/Functional/Controller/Fixtures/Database/TeasAssignedToUser.csv
@@ -1,0 +1,5 @@
+"tx_tea_domain_model_tea"
+,"uid","pid","title","owner"
+,1,2,"Godesberger Burgtee",1
+,2,2,"Oolong",2
+,3,2,"Sencha",0

--- a/Tests/Functional/Controller/Fixtures/Database/Update/UpdatedOwnTea.csv
+++ b/Tests/Functional/Controller/Fixtures/Database/Update/UpdatedOwnTea.csv
@@ -1,0 +1,5 @@
+"tx_tea_domain_model_tea"
+,"uid","pid","title","owner"
+,1,2,"Darjeeling",1
+,2,2,"Oolong",2
+,3,2,"Sencha",0

--- a/Tests/Functional/Controller/FrontendEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontendEditorControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TTN\Tea\Tests\Functional\Controller;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TTN\Tea\Controller\FrontEndEditorController;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+#[CoversClass(FrontEndEditorController::class)]
+final class FrontendEditorControllerTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = ['ttn/tea'];
+
+    protected array $coreExtensionsToLoad = ['typo3/cms-fluid-styled-content'];
+
+    protected array $pathsToLinkInTestInstance = [
+        'typo3conf/ext/tea/Tests/Functional/Controller/Fixtures/Sites/' => 'typo3conf/sites',
+    ];
+
+    protected array $configurationToUseInTestInstance = [
+        'FE' => [
+            'cacheHash' => [
+                'enforceValidation' => false,
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/SiteStructure.csv');
+        $this->setUpFrontendRootPage(1, [
+            'constants' => [
+                'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                'EXT:tea/Configuration/TypoScript/constants.typoscript',
+                'EXT:tea/Tests/Functional/Controller/Fixtures/TypoScript/Constants/PluginConfiguration.typoscript',
+            ],
+            'setup' => [
+                'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                'EXT:tea/Configuration/TypoScript/setup.typoscript',
+                'EXT:tea/Tests/Functional/Controller/Fixtures/TypoScript/Setup/Rendering.typoscript',
+            ],
+        ]);
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/ContentElementTeaFrontEndEditor.csv');
+    }
+
+    #[Test]
+    public function indexActionForNoLoggedInUser(): void
+    {
+        $request = (new InternalRequest())->withPageId(1);
+
+        $html = (string)$this->executeFrontendSubRequest($request)->getBody();
+
+        self::assertStringContainsString('Please configure this plugin to be only visible if a website user is logged in.', $html);
+    }
+
+}

--- a/Tests/Functional/Controller/FrontendEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontendEditorControllerTest.php
@@ -172,7 +172,7 @@ final class FrontendEditorControllerTest extends FunctionalTestCase
 
         $this->executeFrontendSubRequest($request, $context);
 
-        self::assertSame(1, $this->getAllRecords('tx_tea_domain_model_tea')[0]['owner']);
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/Database/Create/CreatedWithOwner.csv');
     }
 
     #[Test]

--- a/Tests/Functional/Controller/FrontendEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontendEditorControllerTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TTN\Tea\Controller\FrontEndEditorController;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 #[CoversClass(FrontEndEditorController::class)]
@@ -47,6 +48,7 @@ final class FrontendEditorControllerTest extends FunctionalTestCase
             ],
         ]);
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/ContentElementTeaFrontEndEditor.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/FrontendUsers.csv');
     }
 
     #[Test]
@@ -57,6 +59,20 @@ final class FrontendEditorControllerTest extends FunctionalTestCase
         $html = (string)$this->executeFrontendSubRequest($request)->getBody();
 
         self::assertStringContainsString('Please configure this plugin to be only visible if a website user is logged in.', $html);
+    }
+
+    #[Test]
+    public function indexActionForLoggedInUserRendersTeasOwnedByTheLoggedInUser(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAssignedToUser.csv');
+
+        $request = (new InternalRequest())->withPageId(1);
+        $context = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $html = (string)$this->executeFrontendSubRequest($request, $context)->getBody();
+
+        self::assertStringContainsString('Godesberger Burgtee', $html);
+        self::assertStringNotContainsString('Oolong', $html);
     }
 
 }

--- a/Tests/Functional/Controller/FrontendEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontendEditorControllerTest.php
@@ -175,6 +175,22 @@ final class FrontendEditorControllerTest extends FunctionalTestCase
         self::assertSame(1, $this->getAllRecords('tx_tea_domain_model_tea')[0]['owner']);
     }
 
+    #[Test]
+    public function deleteActionWithOwnTeaRemovesProvidedTea(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAssignedToUser.csv');
+
+        $request = (new InternalRequest())->withPageId(1)->withQueryParameters([
+            'tx_tea_teafrontendeditor[action]' => 'delete',
+            'tx_tea_teafrontendeditor[tea][__identity]' => '1',
+        ]);
+        $context = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $this->executeFrontendSubRequest($request, $context);
+
+        self::assertSame(1, $this->getAllRecords('tx_tea_domain_model_tea')[0]['deleted']);
+    }
+
     private function getTrustedPropertiesFromEditForm(int $tea, int $userId): string
     {
         $request = (new InternalRequest())->withPageId(1)->withQueryParameters([

--- a/Tests/Functional/Controller/FrontendEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontendEditorControllerTest.php
@@ -188,7 +188,7 @@ final class FrontendEditorControllerTest extends FunctionalTestCase
 
         $this->executeFrontendSubRequest($request, $context);
 
-        self::assertSame(1, $this->getAllRecords('tx_tea_domain_model_tea')[0]['deleted']);
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/Database/Delete/Deleted.csv');
     }
 
     private function getTrustedPropertiesFromEditForm(int $tea, int $userId): string

--- a/Tests/Functional/Controller/FrontendEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontendEditorControllerTest.php
@@ -147,6 +147,19 @@ final class FrontendEditorControllerTest extends FunctionalTestCase
         self::assertSame('Darjeeling', $this->getAllRecords('tx_tea_domain_model_tea')[0]['title']);
     }
 
+    #[Test]
+    public function newActionWithNoProvidedTeaCanBeRendered(): void
+    {
+        $request = (new InternalRequest())->withPageId(1)->withQueryParameters([
+            'tx_tea_teafrontendeditor[action]' => 'new',
+        ]);
+        $context = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $html = (string)$this->executeFrontendSubRequest($request, $context)->getBody();
+
+        self::assertStringContainsString('Create new tea', $html);
+    }
+
     private function getTrustedPropertiesFromEditForm(int $tea, int $userId): string
     {
         $request = (new InternalRequest())->withPageId(1)->withQueryParameters([

--- a/Tests/Functional/Controller/FrontendEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontendEditorControllerTest.php
@@ -160,11 +160,38 @@ final class FrontendEditorControllerTest extends FunctionalTestCase
         self::assertStringContainsString('Create new tea', $html);
     }
 
+    #[Test]
+    public function createActionSetsLoggedInUserAsOwnerOfProvidedTea(): void
+    {
+        $request = (new InternalRequest())->withPageId(1)->withQueryParameters([
+            'tx_tea_teafrontendeditor[__trustedProperties]' => $this->getTrustedPropertiesFromNewForm(1),
+            'tx_tea_teafrontendeditor[action]' => 'create',
+            'tx_tea_teafrontendeditor[tea][title]' => 'Darjeeling',
+        ]);
+        $context = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $this->executeFrontendSubRequest($request, $context);
+
+        self::assertSame(1, $this->getAllRecords('tx_tea_domain_model_tea')[0]['owner']);
+    }
+
     private function getTrustedPropertiesFromEditForm(int $tea, int $userId): string
     {
         $request = (new InternalRequest())->withPageId(1)->withQueryParameters([
             'tx_tea_teafrontendeditor[action]' => 'edit',
             'tx_tea_teafrontendeditor[tea]' => $tea,
+        ]);
+        $context = (new InternalRequestContext())->withFrontendUserId($userId);
+
+        $html = (string)$this->executeFrontendSubRequest($request, $context)->getBody();
+
+        return $this->getTrustedPropertiesFromHtml($html);
+    }
+
+    private function getTrustedPropertiesFromNewForm(int $userId): string
+    {
+        $request = (new InternalRequest())->withPageId(1)->withQueryParameters([
+            'tx_tea_teafrontendeditor[action]' => 'new',
         ]);
         $context = (new InternalRequestContext())->withFrontendUserId($userId);
 

--- a/Tests/Functional/Controller/FrontendEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontendEditorControllerTest.php
@@ -144,7 +144,7 @@ final class FrontendEditorControllerTest extends FunctionalTestCase
 
         $this->executeFrontendSubRequest($request, $context);
 
-        self::assertSame('Darjeeling', $this->getAllRecords('tx_tea_domain_model_tea')[0]['title']);
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/Database/Update/UpdatedOwnTea.csv');
     }
 
     #[Test]

--- a/Tests/Functional/Controller/FrontendEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontendEditorControllerTest.php
@@ -75,4 +75,22 @@ final class FrontendEditorControllerTest extends FunctionalTestCase
         self::assertStringNotContainsString('Oolong', $html);
     }
 
+    #[Test]
+    public function editActionWithOwnTeaAssignsProvidedTeaToView(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAssignedToUser.csv');
+
+        $request = (new InternalRequest())->withPageId(1)->withQueryParameters([
+            'tx_tea_teafrontendeditor[action]' => 'edit',
+            'tx_tea_teafrontendeditor[tea]' => '1',
+        ]);
+        $context = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $html = (string)$this->executeFrontendSubRequest($request, $context)->getBody();
+
+        self::assertStringContainsString('<input type="hidden" name="tx_tea_teafrontendeditor[tea][__identity]" value="1" />', $html);
+        self::assertStringContainsString('Godesberger Burgtee', $html);
+        self::assertStringNotContainsString('Oolong', $html);
+    }
+
 }

--- a/Tests/Functional/Controller/FrontendEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontendEditorControllerTest.php
@@ -111,4 +111,22 @@ final class FrontendEditorControllerTest extends FunctionalTestCase
         $this->executeFrontendSubRequest($request, $context);
     }
 
+    #[Test]
+    public function editActionWithTeaWithoutOwnerThrowsException(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAssignedToUser.csv');
+
+        $request = (new InternalRequest())->withPageId(1)->withQueryParameters([
+            'tx_tea_teafrontendeditor[action]' => 'edit',
+            'tx_tea_teafrontendeditor[tea]' => '2',
+        ]);
+        $context = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('You do not have the permissions to edit this tea.');
+        $this->expectExceptionCode(1687363749);
+
+        $this->executeFrontendSubRequest($request, $context);
+    }
+
 }

--- a/Tests/Functional/Controller/FrontendEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontendEditorControllerTest.php
@@ -93,4 +93,22 @@ final class FrontendEditorControllerTest extends FunctionalTestCase
         self::assertStringNotContainsString('Oolong', $html);
     }
 
+    #[Test]
+    public function editActionWithTeaFromOtherUserThrowsException(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAssignedToUser.csv');
+
+        $request = (new InternalRequest())->withPageId(1)->withQueryParameters([
+            'tx_tea_teafrontendeditor[action]' => 'edit',
+            'tx_tea_teafrontendeditor[tea]' => '2',
+        ]);
+        $context = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('You do not have the permissions to edit this tea.');
+        $this->expectExceptionCode(1687363749);
+
+        $this->executeFrontendSubRequest($request, $context);
+    }
+
 }

--- a/Tests/Functional/Controller/FrontendEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontendEditorControllerTest.php
@@ -191,6 +191,24 @@ final class FrontendEditorControllerTest extends FunctionalTestCase
         $this->assertCSVDataSet(__DIR__ . '/Fixtures/Database/Delete/Deleted.csv');
     }
 
+    #[Test]
+    public function updateActionWithOwnTeaRendersPluginAfterRedirect(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/TeasAssignedToUser.csv');
+
+        $request = (new InternalRequest())->withPageId(1)->withQueryParameters([
+            'tx_tea_teafrontendeditor[__trustedProperties]' => $this->getTrustedPropertiesFromEditForm(1, 1),
+            'tx_tea_teafrontendeditor[action]' => 'update',
+            'tx_tea_teafrontendeditor[tea][__identity]' => '1',
+            'tx_tea_teafrontendeditor[tea][title]' => 'Darjeeling',
+        ]);
+        $context = (new InternalRequestContext())->withFrontendUserId(1);
+
+        $html = (string)$this->executeFrontendSubRequest($request, $context, true)->getBody();
+
+        $this->assertStringContainsString('Tea FrontEnd Editor', $html);
+    }
+
     private function getTrustedPropertiesFromEditForm(int $tea, int $userId): string
     {
         $request = (new InternalRequest())->withPageId(1)->withQueryParameters([

--- a/Tests/Unit/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Unit/Controller/FrontEndEditorControllerTest.php
@@ -90,26 +90,11 @@ final class FrontEndEditorControllerTest extends UnitTestCase
             ->willReturn($redirectResponse);
     }
 
-    #[Test]
-    /**
-     * Not possible to test with functionals due to hmac security.
-     */
-    public function updateActionWithTeaFromOtherUserThrowsException(): void
-    {
-        $this->setUidOfLoggedInUser(1);
-        $tea = new Tea();
-        $tea->setOwnerUid(2);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('You do not have the permissions to edit this tea.');
-        $this->expectExceptionCode(1687363749);
-
-        $this->subject->updateAction($tea);
-    }
 
     #[Test]
     /**
      * Not possible to test with functionals due to hmac security.
+     * Stay with strategy
      */
     public function updateActionWithTeaWithoutOwnerThrowsException(): void
     {
@@ -127,6 +112,7 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     #[Test]
     /**
      * This feature is not implemented in Templates yet, therefore we can't test it with functional tests due to hmac.
+     * Test can be dropped together with simplified newAction (drop $tea parameter)
      */
     public function newActionWithTeaAssignsProvidedTeaToView(): void
     {
@@ -140,6 +126,7 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     #[Test]
     /**
      * Extbase calls `header()` functions instead of using PSR.
+     * Test rendering result instead of redirect
      */
     public function createActionRedirectsToIndexAction(): void
     {

--- a/Tests/Unit/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Unit/Controller/FrontEndEditorControllerTest.php
@@ -92,22 +92,6 @@ final class FrontEndEditorControllerTest extends UnitTestCase
 
     #[Test]
     /**
-     * Extbase calls `header()` functions instead of using PSR.
-     */
-    public function updateActionWithOwnTeaRedirectsToIndexAction(): void
-    {
-        $userUid = 5;
-        $this->setUidOfLoggedInUser($userUid);
-        $tea = new Tea();
-        $tea->setOwnerUid($userUid);
-
-        $this->mockRedirect('index');
-
-        $this->subject->updateAction($tea);
-    }
-
-    #[Test]
-    /**
      * Not possible to test with functionals due to hmac security.
      */
     public function updateActionWithTeaFromOtherUserThrowsException(): void


### PR DESCRIPTION
Controllers should not be covered with unit, but functional tests. We therefore migrate the existing tests.

Relates: #1569