### PR TITLE
[TASK] Do not show the Composer version on CI anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,6 @@ jobs:
           ini-file: development
           coverage: none
           tools: composer:v2
-      - name: Show Composer version
-        run: "composer --version"
       - name: Show the Composer configuration
         run: "composer config --global --list"
       - name: Cache dependencies installed with composer
@@ -177,8 +175,6 @@ jobs:
           tools: composer:v2
           extensions: mysqli
           coverage: none
-      - name: Show Composer version
-        run: "composer --version"
       - name: Show the Composer configuration
         run: "composer config --global --list"
       - name: Cache dependencies installed with composer


### PR DESCRIPTION
This will not be possible anymore when we switch CI to `runTests.sh`.

This is a pre-patch to switching unit and functional tests on GitHub Actions to `runTests.sh`.