### PR TITLE
[TASK] Refactor functional test setup

### DIFF
--- a/Tests/Functional/Controller/AbstractFrontendControllerTestCase.php
+++ b/Tests/Functional/Controller/AbstractFrontendControllerTestCase.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TTN\Tea\Tests\Functional\Controller;
+
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+abstract class AbstractFrontendControllerTestCase extends FunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->testExtensionsToLoad = [
+            'ttn/tea',
+        ];
+
+        $this->coreExtensionsToLoad = [
+            'typo3/cms-fluid-styled-content',
+        ];
+
+        $this->pathsToLinkInTestInstance = [
+            'typo3conf/ext/tea/Tests/Functional/Controller/Fixtures/Sites/' => 'typo3conf/sites',
+        ];
+
+        $this->configurationToUseInTestInstance = [
+            'FE' => [
+                'cacheHash' => [
+                    'enforceValidation' => false,
+                ],
+            ],
+        ];
+
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/SiteStructure.csv');
+        $this->setUpFrontendRootPage(1, [
+            'constants' => [
+                'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
+                'EXT:tea/Configuration/TypoScript/constants.typoscript',
+            ],
+            'setup' => [
+                'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
+                'EXT:tea/Configuration/TypoScript/setup.typoscript',
+                'EXT:tea/Tests/Functional/Controller/Fixtures/TypoScript/Setup/Rendering.typoscript',
+            ],
+        ]);
+    }
+}

--- a/Tests/Functional/Controller/TeaControllerTest.php
+++ b/Tests/Functional/Controller/TeaControllerTest.php
@@ -8,43 +8,14 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TTN\Tea\Controller\TeaController;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
-use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 #[CoversClass(TeaController::class)]
-final class TeaControllerTest extends FunctionalTestCase
+final class TeaControllerTest extends AbstractFrontendControllerTestCase
 {
-    protected array $testExtensionsToLoad = ['ttn/tea'];
-
-    protected array $coreExtensionsToLoad = ['typo3/cms-fluid-styled-content'];
-
-    protected array $pathsToLinkInTestInstance = [
-        'typo3conf/ext/tea/Tests/Functional/Controller/Fixtures/Sites/' => 'typo3conf/sites',
-    ];
-
-    protected array $configurationToUseInTestInstance = [
-        'FE' => [
-            'cacheHash' => [
-                'enforceValidation' => false,
-            ],
-        ],
-    ];
-
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/SiteStructure.csv');
-        $this->setUpFrontendRootPage(1, [
-            'constants' => [
-                'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript',
-                'EXT:tea/Configuration/TypoScript/constants.typoscript',
-            ],
-            'setup' => [
-                'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript',
-                'EXT:tea/Configuration/TypoScript/setup.typoscript',
-                'EXT:tea/Tests/Functional/Controller/Fixtures/TypoScript/Setup/Rendering.typoscript',
-            ],
-        ]);
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/ContentElementTeaIndex.csv');
     }
 


### PR DESCRIPTION
This is a preparation for #1569.
Common setup for frontend related functional tests is moved to an abstract test case. That way all tests can extend this basic setup, which is necessary for common test cases.

Relates: #1569