### PR TITLE
[BUGFIX] Temporarily disable the `composer-unused` runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
         command:
           - "composer:normalize"
           - "composer:psr-verify"
-          - "composer:unused"
           - "json:lint"
           - "php:cs-fixer"
           - "php:mess"

--- a/composer.json
+++ b/composer.json
@@ -150,7 +150,6 @@
 		"ci:php:stan": "phpstan --no-progress -v --configuration=Build/phpstan/phpstan.neon",
 		"ci:static": [
 			"@ci:composer:normalize",
-			"@ci:composer:unused",
 			"@ci:json:lint",
 			"@ci:php:lint",
 			"@ci:php:rector",


### PR DESCRIPTION
This tool currently crashes with certain versions of Xdebug:

https://github.com/composer-unused/composer-unused/issues/688

Hence, we remove it from CI and from `composer ci:static` for the time being to avoid the build failures and to unblock working locally.

(It still is possible to run the `composer composer:unused` command when needed, though.)

Fixes #1715