### PR TITLE
[Task] Fix the runTests.sh for Linux

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -468,7 +468,12 @@ if [ "${CONTAINER_BIN}" == "docker" ]; then
 else
     # podman
     CONTAINER_HOST="host.containers.internal"
-    CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
+    # Add SELinux context labeling (:Z) only on Linux systems where SELinux is available
+    if [ "$(uname)" = "Linux" ]; then
+        CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR}:Z -w ${ROOT_DIR}"
+    else
+        CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
+    fi
 fi
 
 if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
@@ -555,7 +560,7 @@ case ${TEST_SUITE} in
         ;;
     functional)
         [ -z "${TEST_FILE}" ] && TEST_FILE="Tests/Functional"
-        COMMAND=".Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml --exclude-group not-${DBMS} ${EXTRA_TEST_OPTIONS} ${TEST_FILE}"
+        COMMAND="php .Build/vendor/phpunit/phpunit/phpunit -c Build/phpunit/FunctionalTests.xml --exclude-group not-${DBMS} ${EXTRA_TEST_OPTIONS} ${TEST_FILE}"
         case ${DBMS} in
             mariadb)
                 echo "Using driver: ${DATABASE_DRIVER}"
@@ -642,12 +647,12 @@ case ${TEST_SUITE} in
         ;;
     unit)
         [ -z "${TEST_FILE}" ] && TEST_FILE="Tests/Unit"
-        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} .Build/bin/phpunit -c Build/phpunit/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE}
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} /bin/sh -c "php .Build/vendor/phpunit/phpunit/phpunit -c Build/phpunit/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE}"
         SUITE_EXIT_CODE=$?
         ;;
     unitRandom)
         [ -z "${TEST_FILE}" ] && TEST_FILE="Tests/Unit"
-        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-random-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} .Build/bin/phpunit -c Build/phpunit/UnitTests.xml --order-by=random ${EXTRA_TEST_OPTIONS} ${PHPUNIT_RANDOM} ${TEST_FILE}
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name unit-random-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${IMAGE_PHP} /bin/sh -c "php .Build/vendor/phpunit/phpunit/phpunit -c Build/phpunit/UnitTests.xml --order-by=random ${EXTRA_TEST_OPTIONS} ${PHPUNIT_RANDOM} ${TEST_FILE}"
         SUITE_EXIT_CODE=$?
         ;;
     update)


### PR DESCRIPTION
How to reproduce this Issue:
Run `runTests.sh` on Linux with SELinux e.g. Fedora. It fails with Permission denied Error.

Excellent! The fix is now cross-platform compatible. Here's what the updated solution does:

Cross-Platform Fix Summary

Fixed Issues:
1. Permission denied error when running PHPUnit in containers
2. Cross-platform compatibility for Docker/Podman on Linux and macOS

Changes Made:

1. PHPUnit Execution Fix: •  Changed from executing .Build/bin/phpunit (wrapper script with permission issues) •  To using php .Build/vendor/phpunit/phpunit/phpunit (direct PHP execution) •  Applied to all test suites: unit, unitRandom, and functional
2. Platform-Aware Volume Mounting: •  Linux + Podman: Uses -v ${ROOT_DIR}:${ROOT_DIR}:Z (with SELinux context labeling) •  macOS + Podman: Uses -v ${ROOT_DIR}:${ROOT_DIR} (without SELinux flag) •  Docker: Unchanged behavior on all platforms

How It Works:
•  Detects the operating system using uname
•  On Linux systems with Podman, adds the :Z flag for proper SELinux context labeling •  On macOS systems with Podman, omits the :Z flag since SELinux is not available •  Maintains existing Docker behavior unchanged

Benefits:
✅ Linux users get proper SELinux support with Podman   ✅ macOS users can use Podman without SELinux errors   ✅ Docker users on any platform continue to work as before   ✅ All PHPUnit execution methods now bypass permission issues  

The solution is now fully cross-platform and should work seamlessly for Mac users with both Docker and Podman!