### PR TITLE
[TASK] Migrate controller tests to functional tests (editAction)

### DIFF
--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -99,6 +99,44 @@ final class FrontEndEditorControllerTest extends AbstractFrontendControllerTestC
         ]);
     }
 
+    #[Test]
+    public function editActionWithOwnTeaAssignsProvidedTeaToView(): void
+    {
+        $html = $this->getHtmlWithLoggedInUser([
+            'tx_tea_teafrontendeditor[action]' => 'edit',
+            'tx_tea_teafrontendeditor[tea]' => self::UID_OF_TEA_OWNED_BY_LOGGED_IN_USER,
+        ]);
+
+        self::assertStringContainsString('<input type="hidden" name="tx_tea_teafrontendeditor[tea][__identity]" value="1" />', $html);
+        self::assertStringContainsString('Godesberger Burgtee', $html);
+    }
+
+    #[Test]
+    public function editActionWithTeaFromOtherUserThrowsException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('You do not have the permissions to edit this tea.');
+        $this->expectExceptionCode(1687363749);
+
+        $this->executeRequestWithLoggedInUser([
+            'tx_tea_teafrontendeditor[action]' => 'edit',
+            'tx_tea_teafrontendeditor[tea]' => self::UID_OF_TEA_OWNED_BY_FOREIGN_USER,
+        ]);
+    }
+
+    #[Test]
+    public function editActionWithTeaWithoutOwnerThrowsException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('You do not have the permissions to edit this tea.');
+        $this->expectExceptionCode(1687363749);
+
+        $this->executeRequestWithLoggedInUser([
+            'tx_tea_teafrontendeditor[action]' => 'edit',
+            'tx_tea_teafrontendeditor[tea]' => self::UID_OF_TEA_WITHOUT_OWNER,
+        ]);
+    }
+
     /**
      * @param array<string, string> $queryParameters
      */

--- a/Tests/Unit/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Unit/Controller/FrontEndEditorControllerTest.php
@@ -91,60 +91,6 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     }
 
     #[Test]
-    public function editActionWithOwnTeaAssignsProvidedTeaToView(): void
-    {
-        $userUid = 5;
-        $this->setUidOfLoggedInUser($userUid);
-        $tea = new Tea();
-        $tea->setOwnerUid($userUid);
-
-        $this->viewMock->expects(self::once())->method('assign')->with('tea', $tea);
-
-        $this->subject->editAction($tea);
-    }
-
-    #[Test]
-    public function editActionWithTeaFromOtherUserThrowsException(): void
-    {
-        $this->setUidOfLoggedInUser(1);
-        $tea = new Tea();
-        $tea->setOwnerUid(2);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('You do not have the permissions to edit this tea.');
-        $this->expectExceptionCode(1687363749);
-
-        $this->subject->editAction($tea);
-    }
-
-    #[Test]
-    public function editActionWithTeaWithoutOwnerThrowsException(): void
-    {
-        $this->setUidOfLoggedInUser(1);
-        $tea = new Tea();
-        $tea->setOwnerUid(0);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('You do not have the permissions to edit this tea.');
-        $this->expectExceptionCode(1687363749);
-
-        $this->subject->editAction($tea);
-    }
-
-    #[Test]
-    public function editActionForOwnTeaReturnsHtmlResponse(): void
-    {
-        $userUid = 5;
-        $this->setUidOfLoggedInUser($userUid);
-        $tea = new Tea();
-        $tea->setOwnerUid($userUid);
-
-        $result = $this->subject->editAction($tea);
-
-        self::assertInstanceOf(HtmlResponse::class, $result);
-    }
-
-    #[Test]
     public function updateActionWithOwnTeaPersistsProvidedTea(): void
     {
         $userUid = 5;


### PR DESCRIPTION
It is considered best practice to cover controllers via functional instead of unit tests.
We therefore migrate the existing unit tests to functional tests.

The migration is split into multiple batches for smaller changes. This one covers tests related to `editAction()`.

Relates: #1569