### PR TITLE
[TASK] Migrate controller tests to functional tests (updateAction)

### DIFF
--- a/Tests/Functional/Controller/Assertions/Database/FrontEndEditorController/Update/UpdatedTea.csv
+++ b/Tests/Functional/Controller/Assertions/Database/FrontEndEditorController/Update/UpdatedTea.csv
@@ -1,0 +1,3 @@
+"tx_tea_domain_model_tea"
+,"uid","pid","title","owner"
+,1,2,"Darjeeling",1

--- a/Tests/Unit/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Unit/Controller/FrontEndEditorControllerTest.php
@@ -90,20 +90,6 @@ final class FrontEndEditorControllerTest extends UnitTestCase
         self::assertInstanceOf(ActionController::class, $this->subject);
     }
 
-    #[Test]
-    public function updateActionWithOwnTeaPersistsProvidedTea(): void
-    {
-        $userUid = 5;
-        $this->setUidOfLoggedInUser($userUid);
-        $tea = new Tea();
-        $tea->setOwnerUid($userUid);
-        $this->stubRedirect('index');
-
-        $this->teaRepositoryMock->expects(self::once())->method('update')->with($tea);
-
-        $this->subject->updateAction($tea);
-    }
-
     private function mockRedirect(string $actionName): void
     {
         $redirectResponse = self::createStub(RedirectResponse::class);
@@ -115,47 +101,6 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     {
         $redirectResponse = self::createStub(RedirectResponse::class);
         $this->subject->method('redirect')->willReturn($redirectResponse);
-    }
-
-    #[Test]
-    public function updateActionWithOwnTeaRedirectsToIndexAction(): void
-    {
-        $userUid = 5;
-        $this->setUidOfLoggedInUser($userUid);
-        $tea = new Tea();
-        $tea->setOwnerUid($userUid);
-
-        $this->mockRedirect('index');
-
-        $this->subject->updateAction($tea);
-    }
-
-    #[Test]
-    public function updateActionWithTeaFromOtherUserThrowsException(): void
-    {
-        $this->setUidOfLoggedInUser(1);
-        $tea = new Tea();
-        $tea->setOwnerUid(2);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('You do not have the permissions to edit this tea.');
-        $this->expectExceptionCode(1687363749);
-
-        $this->subject->updateAction($tea);
-    }
-
-    #[Test]
-    public function updateActionWithTeaWithoutOwnerThrowsException(): void
-    {
-        $this->setUidOfLoggedInUser(1);
-        $tea = new Tea();
-        $tea->setOwnerUid(0);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('You do not have the permissions to edit this tea.');
-        $this->expectExceptionCode(1687363749);
-
-        $this->subject->updateAction($tea);
     }
 
     #[Test]


### PR DESCRIPTION
It is considered best practice to cover controllers via functional instead of unit tests.
We therefore migrate the existing unit tests to functional tests.

The migration is split into multiple batches for smaller changes. This one covers tests related to `updateAction()`.

Relates: #1569