### PR TITLE
[FEATURE] Add V13.4 to `runTests.sh`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -223,10 +223,11 @@ Options:
             - 15    maintained until 2027-11-11
             - 16    maintained until 2028-11-09
 
-    -t <12.4>
+    -t <12.4|13.4>
         Only with -s composerUpdateMin|composerUpdateMax
         Specifies the TYPO3 CORE Version to be used
             - 12.4: (default) use TYPO3 v12 with typo3/cms-composer-installers ^5
+            - 13.4: use TYPO3 v13 with typo3/cms-composer-installers ^5
 
     -p <8.1|8.2|8.3|8.4>
         Specifies the PHP minor version to be used
@@ -373,7 +374,7 @@ while getopts "a:b:s:d:i:p:e:t:xy:o:nhu" OPT; do
             ;;
         t)
             CORE_VERSION=${OPTARG}
-            if ! [[ ${CORE_VERSION} =~ ^(12.4)$ ]]; then
+            if ! [[ ${CORE_VERSION} =~ ^(12.4|13.4)$ ]]; then
                 INVALID_OPTIONS+=("-t ${OPTARG}")
             fi
             ;;


### PR DESCRIPTION
Now you can use the `-t` flag. V12 is still default. Nevertheless `./Build/Scripts/runTests.sh -s composerUpdateMin -t 13.4` and `composerUpdateMax -t 13.4` is still failing. To fix this we need to alter the composer.json.
V12.4 is working as expected.