### PR TITLE
[TASK] Re-enable composer-unused in CI and in `ci:static`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         command:
           - "composer:normalize"
           - "composer:psr-verify"
+          - "composer:unused"
           - "json:lint"
           - "php:cs-fixer"
           - "php:mess"

--- a/composer.json
+++ b/composer.json
@@ -150,6 +150,7 @@
 		"ci:php:stan": "phpstan --no-progress -v --configuration=Build/phpstan/phpstan.neon",
 		"ci:static": [
 			"@ci:composer:normalize",
+			"@ci:composer:unused",
 			"@ci:json:lint",
 			"@ci:php:lint",
 			"@ci:php:rector",


### PR DESCRIPTION
Now that our container images are using a fixed version of Xdebug, composer-unused is no longer crashing, and we can re-enable it without breaking the build.

This reverts commit 471fd4f5aebb767cfdac926342cf351eee0fa831.