### PR TITLE
[TASK] Also run PSR4-verify on `ci:static`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -153,6 +153,7 @@
 			"@ci:composer:unused",
 			"@ci:json:lint",
 			"@ci:php:lint",
+			"@ci:composer:psr-verify",
 			"@ci:php:rector",
 			"@ci:php:stan",
 			"@ci:php:cs-fixer",


### PR DESCRIPTION
Run it after php-lint as the PSR4 verification needs valid PHP files to work on.