### PR TITLE
[TASK] Migrate controller tests to functional tests (newAction)

### DIFF
--- a/Classes/Controller/FrontEndEditorController.php
+++ b/Classes/Controller/FrontEndEditorController.php
@@ -72,12 +72,10 @@ class FrontEndEditorController extends ActionController
         return $this->redirect('index');
     }
 
-    #[Extbase\IgnoreValidation(['argumentName' => 'tea'])]
-    public function newAction(?Tea $tea = null): ResponseInterface
+    public function newAction(): ResponseInterface
     {
         // Note: We are using `makeInstance` here instead of `new` to allow for XCLASSing.
-        $teaToAssign = $tea ?? GeneralUtility::makeInstance(Tea::class);
-        $this->view->assign('tea', $teaToAssign);
+        $this->view->assign('tea', GeneralUtility::makeInstance(Tea::class));
 
         return $this->htmlResponse();
     }

--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -201,6 +201,16 @@ final class FrontEndEditorControllerTest extends AbstractFrontendControllerTestC
         ]);
     }
 
+    #[Test]
+    public function newActionCanBeCalledByUser(): void
+    {
+        $html = $this->getHtmlWithLoggedInUser([
+            'tx_tea_teafrontendeditor[action]' => 'new',
+        ]);
+
+        self::assertStringContainsString('Create new tea', $html);
+    }
+
     /**
      * @param array<string, string> $queryParameters
      */

--- a/Tests/Unit/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Unit/Controller/FrontEndEditorControllerTest.php
@@ -104,46 +104,6 @@ final class FrontEndEditorControllerTest extends UnitTestCase
     }
 
     #[Test]
-    public function newActionWithTeaAssignsProvidedTeaToView(): void
-    {
-        $tea = new Tea();
-
-        $this->viewMock->expects(self::once())->method('assign')->with('tea', $tea);
-
-        $this->subject->newAction($tea);
-    }
-
-    #[Test]
-    public function newActionWithNullTeaAssignsProvidedNewTeaToView(): void
-    {
-        $tea = new Tea();
-        GeneralUtility::addInstance(Tea::class, $tea);
-
-        $this->viewMock->expects(self::once())->method('assign')->with('tea', $tea);
-
-        $this->subject->newAction(null);
-    }
-
-    #[Test]
-    public function newActionWithoutTeaAssignsProvidedNewTeaToView(): void
-    {
-        $tea = new Tea();
-        GeneralUtility::addInstance(Tea::class, $tea);
-
-        $this->viewMock->expects(self::once())->method('assign')->with('tea', $tea);
-
-        $this->subject->newAction();
-    }
-
-    #[Test]
-    public function newActionReturnsHtmlResponse(): void
-    {
-        $result = $this->subject->newAction();
-
-        self::assertInstanceOf(HtmlResponse::class, $result);
-    }
-
-    #[Test]
     public function createActionSetsLoggedInUserAsOwnerOfProvidedTea(): void
     {
         $userUid = 5;


### PR DESCRIPTION
It is considered best practice to cover controllers via functional instead of unit tests.
We therefore migrate the existing unit tests to functional tests.

The migration is split into multiple batches for smaller changes. This one covers tests related to `newAction()`.

We remove the `$tea` argument from `newAction()`, as the extension does not provide a way in itself to call this action with this argument.

Relates: #1569