### PR TITLE
[TASK] Improve the Composer script names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composerUpdateMax -t 13.4
       - name: Run code quality checks
         run: |
-          Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composer ci:${{ matrix.command }}
+          Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composer check:${{ matrix.command }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Start MySQL
         run: "sudo /etc/init.d/mysql start"
       - name: Run unit tests with coverage
-        run: composer ci:coverage:unit
+        run: composer check:coverage:unit
       - name: Show generated coverage files
         run: "ls -lahR build/coverage/"
       - name: Run functional tests with coverage
@@ -70,11 +70,11 @@ jobs:
           export typo3DatabaseHost="$DB_HOST";
           export typo3DatabaseUsername="$DB_USER";
           export typo3DatabasePassword="$DB_PASSWORD";
-          composer ci:coverage:functional
+          composer check:coverage:functional
       - name: Show generated coverage files
         run: "ls -lahR build/coverage/"
       - name: Merge coverage results
-        run: composer ci:coverage:merge
+        run: composer check:coverage:merge
       - name: Show combined coverage files
         run: "ls -lahR build/logs/"
       - name: Upload coverage results to Coveralls

--- a/.gitlab/pipeline/jobs/composer-normalize.yml
+++ b/.gitlab/pipeline/jobs/composer-normalize.yml
@@ -2,4 +2,4 @@ composer-normalize:
   extends: .default
   stage: codestyle
   script:
-    - composer ci:composer:normalize
+    - composer check:composer:normalize

--- a/.gitlab/pipeline/jobs/composer-psr-verify.yml
+++ b/.gitlab/pipeline/jobs/composer-psr-verify.yml
@@ -2,4 +2,4 @@ composer-psr-verify:
   extends: .default
   stage: codestyle
   script:
-    - composer ci:composer:psr-verify
+    - composer check:composer:psr-verify

--- a/.gitlab/pipeline/jobs/func-v12-php8.1-highest.yml
+++ b/.gitlab/pipeline/jobs/func-v12-php8.1-highest.yml
@@ -11,4 +11,4 @@ func-v12-php8.1-highest:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
-    - composer ci:tests:functional
+    - composer check:tests:functional

--- a/.gitlab/pipeline/jobs/func-v12-php8.1-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-v12-php8.1-lowest.yml
@@ -11,4 +11,4 @@ func-v12-php8.1-lowest:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
-    - composer ci:tests:functional
+    - composer check:tests:functional

--- a/.gitlab/pipeline/jobs/func-v12-php8.2-highest.yml
+++ b/.gitlab/pipeline/jobs/func-v12-php8.2-highest.yml
@@ -11,4 +11,4 @@ func-v12-php8.2-highest:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
-    - composer ci:tests:functional
+    - composer check:tests:functional

--- a/.gitlab/pipeline/jobs/func-v12-php8.2-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-v12-php8.2-lowest.yml
@@ -11,4 +11,4 @@ func-v12-php8.2-lowest:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
-    - composer ci:tests:functional
+    - composer check:tests:functional

--- a/.gitlab/pipeline/jobs/func-v12-php8.3-highest.yml
+++ b/.gitlab/pipeline/jobs/func-v12-php8.3-highest.yml
@@ -11,4 +11,4 @@ func-v12-php8.3-highest:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
-    - composer ci:tests:functional
+    - composer check:tests:functional

--- a/.gitlab/pipeline/jobs/func-v12-php8.3-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-v12-php8.3-lowest.yml
@@ -11,4 +11,4 @@ func-v12-php8.3-lowest:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
-    - composer ci:tests:functional
+    - composer check:tests:functional

--- a/.gitlab/pipeline/jobs/func-v12-php8.4-highest.yml
+++ b/.gitlab/pipeline/jobs/func-v12-php8.4-highest.yml
@@ -11,4 +11,4 @@ func-v12-php8.4-highest:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies
-    - composer ci:tests:functional
+    - composer check:tests:functional

--- a/.gitlab/pipeline/jobs/func-v12-php8.4-lowest.yml
+++ b/.gitlab/pipeline/jobs/func-v12-php8.4-lowest.yml
@@ -11,4 +11,4 @@ func-v12-php8.4-lowest:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
-    - composer ci:tests:functional
+    - composer check:tests:functional

--- a/.gitlab/pipeline/jobs/javascript-lint.yml
+++ b/.gitlab/pipeline/jobs/javascript-lint.yml
@@ -2,10 +2,10 @@ javascript-lint:
   extends: .default-frontend
   stage: lint
   script:
-    - npm run ci:lint:js
+    - npm run check:lint:js
 
 style-lint:
   extends: .default-frontend
   stage: lint
   script:
-    - npm run ci:lint:css
+    - npm run check:lint:css

--- a/.gitlab/pipeline/jobs/json-lint.yml
+++ b/.gitlab/pipeline/jobs/json-lint.yml
@@ -4,4 +4,4 @@ json-lint:
   needs:
     - build-composer-dependencies
   script:
-    - composer ci:json:lint
+    - composer check:json:lint

--- a/.gitlab/pipeline/jobs/php-cs-fixer.yml
+++ b/.gitlab/pipeline/jobs/php-cs-fixer.yml
@@ -8,4 +8,4 @@ php-cs-fixer:
     - php-lint-php8.3
     - php-lint-php8.4
   script:
-    - composer ci:php:cs-fixer
+    - composer check:php:cs-fixer

--- a/.gitlab/pipeline/jobs/php-lint-php8.1.yml
+++ b/.gitlab/pipeline/jobs/php-lint-php8.1.yml
@@ -4,4 +4,4 @@ php-lint-php8.1:
   stage: lint
   needs: [ ]
   script:
-    - composer ci:php:lint
+    - composer check:php:lint

--- a/.gitlab/pipeline/jobs/php-lint-php8.2.yml
+++ b/.gitlab/pipeline/jobs/php-lint-php8.2.yml
@@ -4,4 +4,4 @@ php-lint-php8.2:
   stage: lint
   needs: [ ]
   script:
-    - composer ci:php:lint
+    - composer check:php:lint

--- a/.gitlab/pipeline/jobs/php-lint-php8.3.yml
+++ b/.gitlab/pipeline/jobs/php-lint-php8.3.yml
@@ -4,4 +4,4 @@ php-lint-php8.3:
   stage: lint
   needs: [ ]
   script:
-    - composer ci:php:lint
+    - composer check:php:lint

--- a/.gitlab/pipeline/jobs/php-lint-php8.4.yml
+++ b/.gitlab/pipeline/jobs/php-lint-php8.4.yml
@@ -4,4 +4,4 @@ php-lint-php8.4:
   stage: lint
   needs: [ ]
   script:
-    - composer ci:php:lint
+    - composer check:php:lint

--- a/.gitlab/pipeline/jobs/phpstan.yml
+++ b/.gitlab/pipeline/jobs/phpstan.yml
@@ -8,4 +8,4 @@ phpstan:
     - php-lint-php8.3
     - php-lint-php8.4
   script:
-    - composer ci:php:stan
+    - composer check:php:stan

--- a/.gitlab/pipeline/jobs/rector.yml
+++ b/.gitlab/pipeline/jobs/rector.yml
@@ -8,4 +8,4 @@ rector:
     - php-lint-php8.3
     - php-lint-php8.4
   script:
-    - composer ci:php:rector
+    - composer check:php:rector

--- a/.gitlab/pipeline/jobs/typoscript-lint.yml
+++ b/.gitlab/pipeline/jobs/typoscript-lint.yml
@@ -4,4 +4,4 @@ ts-lint:
   needs:
     - build-composer-dependencies
   script:
-    - composer ci:typoscript:lint
+    - composer check:typoscript:lint

--- a/.gitlab/pipeline/jobs/unit-v12-php8.1-highest.yml
+++ b/.gitlab/pipeline/jobs/unit-v12-php8.1-highest.yml
@@ -8,4 +8,4 @@ unit-v12-php8.1-highest:
   script:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-progress typo3/cms-core:"^12.4"
-    - composer ci:tests:unit
+    - composer check:tests:unit

--- a/.gitlab/pipeline/jobs/unit-v12-php8.1-lowest.yml
+++ b/.gitlab/pipeline/jobs/unit-v12-php8.1-lowest.yml
@@ -9,4 +9,4 @@ unit-v12-php8.1-lowest:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
-    - composer ci:tests:unit
+    - composer check:tests:unit

--- a/.gitlab/pipeline/jobs/unit-v12-php8.2-highest.yml
+++ b/.gitlab/pipeline/jobs/unit-v12-php8.2-highest.yml
@@ -8,4 +8,4 @@ unit-v12-php8.2-highest:
   script:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-progress typo3/cms-core:"^12.4"
-    - composer ci:tests:unit
+    - composer check:tests:unit

--- a/.gitlab/pipeline/jobs/unit-v12-php8.2-lowest.yml
+++ b/.gitlab/pipeline/jobs/unit-v12-php8.2-lowest.yml
@@ -9,4 +9,4 @@ unit-v12-php8.2-lowest:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
-    - composer ci:tests:unit
+    - composer check:tests:unit

--- a/.gitlab/pipeline/jobs/unit-v12-php8.3-highest.yml
+++ b/.gitlab/pipeline/jobs/unit-v12-php8.3-highest.yml
@@ -8,4 +8,4 @@ unit-v12-php8.3-highest:
   script:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-progress typo3/cms-core:"^12.4"
-    - composer ci:tests:unit
+    - composer check:tests:unit

--- a/.gitlab/pipeline/jobs/unit-v12-php8.3-lowest.yml
+++ b/.gitlab/pipeline/jobs/unit-v12-php8.3-lowest.yml
@@ -9,4 +9,4 @@ unit-v12-php8.3-lowest:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-ansi --no-interaction --no-progress --no-install typo3/cms-core:"^12.4"
     - composer update --no-ansi --no-interaction --no-progress --with-dependencies --prefer-lowest
-    - composer ci:tests:unit
+    - composer check:tests:unit

--- a/.gitlab/pipeline/jobs/unit-v12-php8.4-highest.yml
+++ b/.gitlab/pipeline/jobs/unit-v12-php8.4-highest.yml
@@ -8,4 +8,4 @@ unit-v12-php8.4-highest:
   script:
     - echo "Job ${CI_JOB_NAME}"
     - composer require --no-progress typo3/cms-core:"^12.4"
-    - composer ci:tests:unit
+    - composer check:tests:unit

--- a/.gitlab/pipeline/jobs/xliff-lint.yml
+++ b/.gitlab/pipeline/jobs/xliff-lint.yml
@@ -4,4 +4,4 @@ xliff-lint:
   needs:
     - build-composer-dependencies
   script:
-    - composer ci:xliff:lint
+    - composer check:xliff:lint

--- a/.gitlab/pipeline/jobs/yaml-lint.yml
+++ b/.gitlab/pipeline/jobs/yaml-lint.yml
@@ -4,4 +4,4 @@ yaml-lint:
   needs:
     - build-composer-dependencies
   script:
-    - composer ci:yaml:lint
+    - composer check:yaml:lint

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -492,7 +492,7 @@ fi
 case ${TEST_SUITE} in
     cgl)
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="composer ci:php:cs-fixer"
+            COMMAND="composer check:php:cs-fixer"
         else
             COMMAND="composer fix:php:cs"
         fi
@@ -529,9 +529,9 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     composerNormalize)
-        COMMAND="composer ci:composer:normalize"
+        COMMAND="composer check:composer:normalize"
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="composer ci:composer:normalize"
+            COMMAND="composer check:composer:normalize"
         else
             COMMAND="composer fix:composer:normalize"
         fi
@@ -539,7 +539,7 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     composerUnused)
-        COMMAND="composer ci:composer:unused"
+        COMMAND="composer check:composer:unused"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-unused-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
@@ -596,18 +596,18 @@ case ${TEST_SUITE} in
         esac
         ;;
     lintTypoScript)
-        COMMAND="composer ci:typoscript:lint"
+        COMMAND="composer check:typoscript:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
     lintPhp)
-        COMMAND="composer ci:php:lint"
+        COMMAND="composer check:php:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
     lintJs)
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run ci:lint:js"
+            COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run check:lint:js"
         else
             COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run fix:lint:js"
         fi
@@ -616,7 +616,7 @@ case ${TEST_SUITE} in
         ;;
     lintCss)
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run ci:lint:css"
+            COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run check:lint:css"
         else
             COMMAND="echo ${HELP_TEXT_NPM_CI}; npm ci --silent || { echo ${HELP_TEXT_NPM_FAILURE}; exit 1; } && npm run fix:lint:css"
         fi
@@ -624,12 +624,12 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     lintJson)
-        COMMAND="composer ci:json:lint"
+        COMMAND="composer check:json:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
     lintYaml)
-        COMMAND="composer ci:yaml:lint"
+        COMMAND="composer check:yaml:lint"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;
@@ -639,7 +639,7 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     phpstan)
-        COMMAND="composer ci:php:stan"
+        COMMAND="composer check:php:stan"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;

--- a/Documentation/Running.rst
+++ b/Documentation/Running.rst
@@ -33,7 +33,7 @@ recommended to execute tests with the usage of the `runTests.sh` script.
 
 .. code-block:: bash
 
-    ./Build/Scripts/runTests.sh -s composer ci:php:lint
+    ./Build/Scripts/runTests.sh -s composer check:php:lint
 
 It is not necessary to executing the tests only with the composer scripts.
 You can also use the `runTests.sh`. This makes your life easier because you
@@ -52,66 +52,66 @@ Running code checks
 
 You can currently run these code checks on the command line:
 
-.. index:: Commands; composer ci:composer:normalize
+.. index:: Commands; composer check:composer:normalize
 .. code-block:: bash
 
-    ./Build/Scripts/runTests.sh -s composer ci:composer:normalize
+    ./Build/Scripts/runTests.sh -s composer check:composer:normalize
 
 Checks the composer.json.
 
-.. index:: Commands; composer ci:json:lint
+.. index:: Commands; composer check:json:lint
 .. code-block:: bash
 
-    ./Build/Scripts/runTests.sh -s composer ci:json:lint
+    ./Build/Scripts/runTests.sh -s composer check:json:lint
 
 Lints the JSON files.
 
-.. index:: Commands; composer ci:php
+.. index:: Commands; composer check:php
 .. code-block:: bash
 
-    ./Build/Scripts/runTests.sh -s composer ci:php
+    ./Build/Scripts/runTests.sh -s composer check:php
 
 Runs all static checks for the PHP files.
 
-.. index:: Commands; composer ci:php:cs-fixer
+.. index:: Commands; composer check:php:cs-fixer
 .. code-block:: bash
 
-    ./Build/Scripts/runTests.sh -s composer ci:php:cs-fixer
+    ./Build/Scripts/runTests.sh -s composer check:php:cs-fixer
 
 Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).
 
-.. index:: Commands; composer ci:php:lint
+.. index:: Commands; composer check:php:lint
 .. code-block:: bash
 
-    ./Build/Scripts/runTests.sh -s composer ci:php:lint
+    ./Build/Scripts/runTests.sh -s composer check:php:lint
 
 Lints the PHP files for syntax errors.
 
-.. index:: Commands; composer ci:php:stan
+.. index:: Commands; composer check:php:stan
 .. code-block:: bash
 
-    ./Build/Scripts/runTests.sh -s composer ci:php:stan
+    ./Build/Scripts/runTests.sh -s composer check:php:stan
 
 Checks the PHP types using PHPStan.
 
-.. index:: Commands; composer ci:static
+.. index:: Commands; composer check:static
 .. code-block:: bash
 
-    ./Build/Scripts/runTests.sh -s composer ci:static
+    ./Build/Scripts/runTests.sh -s composer check:static
 
 Runs all static code checks (syntax, style, types).
 
-.. index:: Commands; composer ci:typoscript:lint
+.. index:: Commands; composer check:typoscript:lint
 .. code-block:: bash
 
-    ./Build/Scripts/runTests.sh -scomposer ci:typoscript:lint
+    ./Build/Scripts/runTests.sh -scomposer check:typoscript:lint
 
 Lints the TypoScript files.
 
-.. index:: Commands; composer ci:yaml:lint
+.. index:: Commands; composer check:yaml:lint
 .. code-block:: bash
 
-    ./Build/Scripts/runTests.sh -s composer ci:yaml:lint
+    ./Build/Scripts/runTests.sh -s composer check:yaml:lint
 
 Lints the YAML files.
 
@@ -163,7 +163,7 @@ Running unit and functional tests
 
 You can currently run these tests on the command line:
 
-.. index:: Commands; composer ci:tests:functional
+.. index:: Commands; composer check:tests:functional
 .. code-block:: bash
 
     ./Build/Scripts/runTests.sh -s functional
@@ -176,7 +176,7 @@ Runs the functional tests.
     it is recommended to run the functional tests using :code:`runTests.sh`
     instead of locally.
 
-.. index:: Commands; composer ci:tests:unit
+.. index:: Commands; composer check:tests:unit
 .. code-block:: bash
 
     ./Build/Scripts/runTests.sh -s unit

--- a/composer.json
+++ b/composer.json
@@ -117,59 +117,59 @@
 		}
 	},
 	"scripts": {
-		"ci:composer:normalize": "@composer normalize --no-check-lock --dry-run",
-		"ci:composer:psr-verify": "@composer dumpautoload --optimize --strict-psr --no-plugins",
-		"ci:composer:unused": "composer-unused --configuration=Build/composer-unused/composer-unused.php",
-		"ci:coverage": [
-			"@ci:coverage:unit",
-			"@ci:coverage:functional"
+		"check:composer:normalize": "@composer normalize --no-check-lock --dry-run",
+		"check:composer:psr-verify": "@composer dumpautoload --optimize --strict-psr --no-plugins",
+		"check:composer:unused": "composer-unused --configuration=Build/composer-unused/composer-unused.php",
+		"check:coverage": [
+			"@check:coverage:unit",
+			"@check:coverage:functional"
 		],
-		"ci:coverage:functional": [
-			"@ci:tests:create-directories",
+		"check:coverage:functional": [
+			"@check:tests:create-directories",
 			"@coverage:create-directories",
 			"phpunit -c Build/phpunit/FunctionalTests.xml --coverage-php=build/coverage/functional.cov"
 		],
-		"ci:coverage:merge": [
+		"check:coverage:merge": [
 			"@coverage:create-directories",
 			"@php tools/phpcov merge --clover=build/logs/clover.xml build/coverage/"
 		],
-		"ci:coverage:unit": [
+		"check:coverage:unit": [
 			"@coverage:create-directories",
 			"phpunit -c Build/phpunit/UnitTests.xml --coverage-php=build/coverage/unit.cov"
 		],
-		"ci:json:lint": "find . ! -path '*/.cache/*' ! -path '*/.Build/*' ! -path '*/node_modules/*' -name '*.json' | xargs -r php .Build/bin/jsonlint -q",
-		"ci:php": [
-			"@ci:php:cs-fixer",
-			"@ci:php:lint",
-			"@ci:php:stan"
+		"check:json:lint": "find . ! -path '*/.cache/*' ! -path '*/.Build/*' ! -path '*/node_modules/*' -name '*.json' | xargs -r php .Build/bin/jsonlint -q",
+		"check:php": [
+			"@check:php:cs-fixer",
+			"@check:php:lint",
+			"@check:php:stan"
 		],
-		"ci:php:cs-fixer": "php-cs-fixer fix --config ./Build/php-cs-fixer/php-cs-fixer.php -v --dry-run --diff",
-		"ci:php:lint": "parallel-lint *.php Build Classes Configuration Tests",
-		"ci:php:mess": "phpmd Classes text Build/phpmd/phpmd.xml",
-		"ci:php:rector": "rector --dry-run --config=./Build/rector/rector.php",
-		"ci:php:stan": "phpstan --no-progress -v --configuration=Build/phpstan/phpstan.neon",
-		"ci:static": [
-			"@ci:composer:normalize",
-			"@ci:composer:unused",
-			"@ci:json:lint",
-			"@ci:php:lint",
-			"@ci:composer:psr-verify",
-			"@ci:php:rector",
-			"@ci:php:stan",
-			"@ci:php:cs-fixer",
-			"@ci:typoscript:lint",
-			"@ci:xliff:lint",
-			"@ci:yaml:lint"
+		"check:php:cs-fixer": "php-cs-fixer fix --config ./Build/php-cs-fixer/php-cs-fixer.php -v --dry-run --diff",
+		"check:php:lint": "parallel-lint *.php Build Classes Configuration Tests",
+		"check:php:mess": "phpmd Classes text Build/phpmd/phpmd.xml",
+		"check:php:rector": "rector --dry-run --config=./Build/rector/rector.php",
+		"check:php:stan": "phpstan --no-progress -v --configuration=Build/phpstan/phpstan.neon",
+		"check:static": [
+			"@check:composer:normalize",
+			"@check:composer:unused",
+			"@check:json:lint",
+			"@check:php:lint",
+			"@check:composer:psr-verify",
+			"@check:php:rector",
+			"@check:php:stan",
+			"@check:php:cs-fixer",
+			"@check:typoscript:lint",
+			"@check:xliff:lint",
+			"@check:yaml:lint"
 		],
-		"ci:tests:create-directories": "mkdir -p .Build/public/typo3temp/var/tests",
-		"ci:tests:functional": [
-			"@ci:tests:create-directories",
+		"check:tests:create-directories": "mkdir -p .Build/public/typo3temp/var/tests",
+		"check:tests:functional": [
+			"@check:tests:create-directories",
 			"phpunit -c Build/phpunit/FunctionalTests.xml"
 		],
-		"ci:tests:unit": "phpunit -c Build/phpunit/UnitTests.xml",
-		"ci:typoscript:lint": "typoscript-lint -c Build/typoscript-lint/TypoScriptLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript Tests/Functional/Controller/Fixtures/TypoScript",
-		"ci:xliff:lint": "php Build/xliff/xliff-lint lint:xliff Resources/Private/Language",
-		"ci:yaml:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' \\( -name '*.yaml' -o -name '*.yml' \\) | xargs -r php ./.Build/bin/yaml-lint",
+		"check:tests:unit": "phpunit -c Build/phpunit/UnitTests.xml",
+		"check:typoscript:lint": "typoscript-lint -c Build/typoscript-lint/TypoScriptLint.yml --ansi -n --fail-on-warnings -vvv Configuration/TypoScript Tests/Functional/Controller/Fixtures/TypoScript",
+		"check:xliff:lint": "php Build/xliff/xliff-lint lint:xliff Resources/Private/Language",
+		"check:yaml:lint": "find . ! -path '*.Build/*' ! -path '*node_modules/*' \\( -name '*.yaml' -o -name '*.yml' \\) | xargs -r php ./.Build/bin/yaml-lint",
 		"coverage:create-directories": "mkdir -p build/coverage build/logs",
 		"docs:generate": "docker run --rm --pull always -v $(pwd):/project -it ghcr.io/typo3-documentation/render-guides:latest --config=Documentation",
 		"fix": [
@@ -203,26 +203,26 @@
 		]
 	},
 	"scripts-descriptions": {
-		"ci:composer:normalize": "Checks the composer.json.",
-		"ci:composer:psr-verify": "Verifies PSR-4 namespace correctness.",
-		"ci:composer:unused": "Finds unused Composer packages required in composer.json.",
-		"ci:coverage:functional": "Generates the code coverage report for functional tests.",
-		"ci:coverage:merge": "Merges the code coverage reports for unit and functional tests.",
-		"ci:coverage:unit": "Generates the code coverage report for unit tests.",
-		"ci:json:lint": "Lints the JSON files.",
-		"ci:php": "Runs all static checks for the PHP files.",
-		"ci:php:cs-fixer": "Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).",
-		"ci:php:lint": "Lints the PHP files for syntax errors.",
-		"ci:php:mess": "Runs PHP mess detection.",
-		"ci:php:rector": "Checks for code for changes by Rector.",
-		"ci:php:stan": "Checks the PHP types using PHPStan.",
-		"ci:static": "Runs all static code checks (syntax, style, types).",
-		"ci:tests:create-directories": "Creates the directories required to smoothely run the functional tests.",
-		"ci:tests:functional": "Runs the functional tests.",
-		"ci:tests:unit": "Runs the unit tests.",
-		"ci:typoscript:lint": "Lints the TypoScript files.",
-		"ci:xliff:lint": "Lints the XLIFF files.",
-		"ci:yaml:lint": "Lints the YAML files.",
+		"check:composer:normalize": "Checks the composer.json.",
+		"check:composer:psr-verify": "Verifies PSR-4 namespace correctness.",
+		"check:composer:unused": "Finds unused Composer packages required in composer.json.",
+		"check:coverage:functional": "Generates the code coverage report for functional tests.",
+		"check:coverage:merge": "Merges the code coverage reports for unit and functional tests.",
+		"check:coverage:unit": "Generates the code coverage report for unit tests.",
+		"check:json:lint": "Lints the JSON files.",
+		"check:php": "Runs all static checks for the PHP files.",
+		"check:php:cs-fixer": "Checks the code style with the PHP Coding Standards Fixer (PHP-CS-Fixer).",
+		"check:php:lint": "Lints the PHP files for syntax errors.",
+		"check:php:mess": "Runs PHP mess detection.",
+		"check:php:rector": "Checks for code for changes by Rector.",
+		"check:php:stan": "Checks the PHP types using PHPStan.",
+		"check:static": "Runs all static code checks (syntax, style, types).",
+		"check:tests:create-directories": "Creates the directories required to smoothely run the functional tests.",
+		"check:tests:functional": "Runs the functional tests.",
+		"check:tests:unit": "Runs the unit tests.",
+		"check:typoscript:lint": "Lints the TypoScript files.",
+		"check:xliff:lint": "Lints the XLIFF files.",
+		"check:yaml:lint": "Lints the YAML files.",
 		"coverage:create-directories": "Creates the directories needed for recording and merging the code coverage reports.",
 		"docs:generate": "Renders the extension ReST documentation.",
 		"fix": "Runs all automatic code style fixes.",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
 		"npm": "^9.6.5 || ^10.8.2"
 	},
 	"scripts": {
-		"ci:lint:js": "eslint --config ./Build/eslint/eslint.config.js 'Resources/Public/**/*.js'",
+		"check:lint:js": "eslint --config ./Build/eslint/eslint.config.js 'Resources/Public/**/*.js'",
 		"fix:lint:js": "eslint --config ./Build/eslint/eslint.config.js 'Resources/Public/**/*.js' --quiet --fix",
-		"ci:lint:css": "stylelint --config ./Build/stylelint/stylelint.config.js Resources/Public/**/*.css",
+		"check:lint:css": "stylelint --config ./Build/stylelint/stylelint.config.js Resources/Public/**/*.css",
 		"fix:lint:css": "stylelint --config ./Build/stylelint/stylelint.config.js Resources/Public/**/*.css --fix"
 	},
 	"devDependencies": {


### PR DESCRIPTION
As long as we still are using the Composer scripts, the names should not be misleading.

We have had scripts with the `ci:` prefix for a long time.

However, these scripts are not only for CI, but generally for checks that can (mostly) also be run locally.

So this prefix now has been changed to `check:` to be less misleading.