### PR TITLE
[BUGFIX] Remove cacheDirectory from PHPUnit config

### DIFF
--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -5,7 +5,6 @@
     backupGlobals="true"
     beStrictAboutTestsThatDoNotTestAnything="false"
     bootstrap="../../.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
-    cacheDirectory=".phpunit.cache"
     cacheResult="false"
     colors="true"
     failOnRisky="true"

--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -4,7 +4,6 @@
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
     beStrictAboutTestsThatDoNotTestAnything="false"
     bootstrap="../../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
-    cacheDirectory=".phpunit.cache"
     cacheResult="false"
     colors="true"
     failOnRisky="true"


### PR DESCRIPTION
This is done to avoid the creation of Build/phpunit/.phpunit.cache/ upon test runs

Resolves #1691 
