### PR TITLE
[TASK] Use the default PHP version for the QA checks on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
       - name: Show the Composer configuration
         run:  ./Build/Scripts/runTests.sh -s composer config --global --list
       - name: Install Composer dependencies
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composerUpdateMax
+        run: Build/Scripts/runTests.sh -s composerUpdateMax
       - name: Run code quality checks
         run: |
-          Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composer check:${{ matrix.command }}
+          Build/Scripts/runTests.sh -s composer check:${{ matrix.command }}
     strategy:
       fail-fast: false
       matrix:
@@ -62,8 +62,6 @@ jobs:
           - "typoscript:lint"
           - "xliff:lint"
           - "yaml:lint"
-        php-version:
-          - "8.3"
   prepare-release:
     name: Check prepare release script
     runs-on: ubuntu-24.04

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -65,8 +65,5 @@ parameters:
 
   ignoreErrors:
     -
-      # Ignore for now, as we still support PHP < 8.3
-      message: '#Out of \d possible constant types#'
-    -
       message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) .* will always evaluate to#'
       path: '../../Tests/'


### PR DESCRIPTION
This makes the results on CI mirror the local default behavior more closely to improve DX.