### PR TITLE
[BUGFIX] Be less specific in the TYPO3 dev depencency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
 		"symfony/yaml": "6.4.25 || 7.3.3",
 		"tomasvotruba/cognitive-complexity": "0.2.3 || 1.0.0",
 		"tomasvotruba/type-coverage": "1.0.0 || 2.0.2",
-		"typo3/cms-fluid-styled-content": "^12.4.31 || ^13.4",
+		"typo3/cms-fluid-styled-content": "^12.4 || ^13.4",
 		"typo3/coding-standards": "0.8.0",
 		"typo3/testing-framework": "8.2.7",
 		"webmozart/assert": "^1.12.0"


### PR DESCRIPTION
Requiring a specific bugfix version of a TYPO3 package as a developing dependency would also limit the minimum version of the other Core packages. This defeats the purpose of testing with the lowest allowed TYPO3 version.