### PR TITLE
[BUGFIX] Fix a copy'n'paste error in the PHPMD configuration

### DIFF
--- a/Build/phpmd/phpmd.xml
+++ b/Build/phpmd/phpmd.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="phpList">
+<ruleset name="tea">
     <description>
         PHPMD rules for Tea
     </description>


### PR DESCRIPTION
The ruleset still had the name of the project it was copied from.

Fixes #1801