### PR TITLE
[TASK] Migrate composer normalize in gitlab action

### DIFF
--- a/.gitlab/pipeline/jobs/composer-normalize.yml
+++ b/.gitlab/pipeline/jobs/composer-normalize.yml
@@ -2,4 +2,4 @@ composer-normalize:
   extends: .default
   stage: codestyle
   script:
-    - composer check:composer:normalize
+    - Build/Scripts/runTests.sh -s composer check:composer:normalize


### PR DESCRIPTION
Change gitlab action to use `runTests.sh` for composer normalize.

Related: #1751