### PR TITLE
[TASK] Fix expected type in test name

### DIFF
--- a/Tests/Functional/Domain/Repository/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/TeaRepositoryTest.php
@@ -39,7 +39,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
     }
 
     #[Test]
-    public function findAllForNoRecordsReturnsEmptyContainer(): void
+    public function findAllForNoRecordsReturnsEmptyQueryResult(): void
     {
         $result = $this->subject->findAll();
 


### PR DESCRIPTION
The tested repository method does not return any type of container (as the test name suggested), but a query result. Adapt the test name accordingly.