### PR TITLE
[TASK] Make the Composer script names more consistent

### DIFF
--- a/Documentation/Running.rst
+++ b/Documentation/Running.rst
@@ -128,10 +128,10 @@ Runs all fixers (except for the ones that need JavaScript).
 
 Runs all fixers for the PHP code.
 
-.. index:: Commands; composer fix:php:cs
+.. index:: Commands; composer fix:php:cs-fixer
 .. code-block:: bash
 
-    ./Build/Scripts/runTests.sh -s composer fix:php:cs
+    ./Build/Scripts/runTests.sh -s composer fix:php:cs-fixer
 
 Fixes the code style with PHP-CS-Fixer.
 

--- a/composer.json
+++ b/composer.json
@@ -178,9 +178,9 @@
 		"fix:composer:normalize": "@composer normalize --no-check-lock",
 		"fix:php": [
 			"@fix:php:rector",
-			"@fix:php:cs"
+			"@fix:php:cs-fixer"
 		],
-		"fix:php:cs": "php-cs-fixer fix --config ./Build/php-cs-fixer/php-cs-fixer.php",
+		"fix:php:cs-fixer": "php-cs-fixer fix --config ./Build/php-cs-fixer/php-cs-fixer.php",
 		"fix:php:rector": "rector --config=./Build/rector/rector.php",
 		"phpstan:baseline": "phpstan --generate-baseline=Build/phpstan/phpstan-baseline.neon --allow-empty-baseline --configuration=Build/phpstan/phpstan.neon",
 		"prepare-release": [
@@ -226,7 +226,7 @@
 		"fix": "Runs all automatic code style fixes.",
 		"fix:composer:normalize": "Normalizes composer.json file content.",
 		"fix:php": "Runs all fixers for the PHP code.",
-		"fix:php:cs": "Fixes the code style with PHP-CS-Fixer.",
+		"fix:php:cs-fixer": "Fixes the code style with PHP-CS-Fixer.",
 		"fix:php:rector": "Updates the code with Rector.",
 		"phpstan:baseline": "Updates the PHPStan baseline file to match the code.",
 		"prepare-release": "Removes development-only files in preparation of a TER release."


### PR DESCRIPTION
The check script is named `check:php:cs-fixer`. So the related fixer script should be named `fix:php:cs-fixer` for consistency.

Fixes #1861