### PR TITLE
[TASK] Rework the GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,24 +1,32 @@
 ---
 name: Bug
-about: If you want a new bug
-title: "Bug: Please add a speaking title"
-labels: 'bug'
-type: 'bug'
+about: Something is broken.
+title: ''
+type: bug
 assignees: ''
 
 ---
 
-## Short problem description
-Describe the problem in short
+## Summary
+
+(one or two sentences summarizing the problem)
 
 ## Steps to reproduce the problem
-What steps are necessary to reproduce the problem
 
-## actual behavior
-What is the actual behavior
+1. …
+2. …
+3. …
+4. …
 
-## expected behavior
-What behavior is expected
+## Actual behavior
 
-## Additional Information
-Anything else that would be helpful to know to complete this task.
+(A description of the faulty behavior you're seeing. Add error messages or
+screenshot if possible/helpful.)
+
+## Expected behaviour
+
+(what you expect to happen instead)
+
+## Additional information
+
+(additional information that might help understand and fix this bug)

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,17 +1,21 @@
 ---
 name: Feature
-about: If you want a new feature
-title: "Feature: Please add a speaking title"
-labels: 'feature'
+about: We would like to have something new.
+title: ''
+type: feature
 assignees: ''
 
 ---
 
-## Goal
-What would you like to achieve with this feature? Maybe in form of a User Story.
+## Story
 
-## Acceptance Criteria
-- [ ] 
+As …, I want …, because ….
 
-## Additional Information
-Anything else that would be helpful to know to implement this feature.
+## Acceptance criteria
+
+- [ ] …
+- [ ] …
+
+## Additional information
+
+(additional information that might help understand and implement this feature)

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,17 +1,21 @@
 ---
 name: Task
-about: If you want a new task
-title: "Task: Please add a speaking title"
-labels: 'task'
+about: Something is to be done, and it is neither a bug nor a new feature.
+title: ''
+type: task
 assignees: ''
 
 ---
 
-## Goal
-What would you like to achieve with this task? Maybe in form of a User Story.
+## Story
 
-## Acceptance Criteria
-- [ ] 
+As …, I want …, because ….
 
-## Additional Information
-Anything else that would be helpful to know to complete this task.
+## Acceptance criteria
+
+- [ ] …
+- [ ] …
+
+## Additional information
+
+(additional information that might help understand and implement this task)


### PR DESCRIPTION
Also drop the redundant issue types from the issue title and the labels.

Fixes #1304