### PR TITLE
[TASK] Drop PHPDoc type annotations for constants

### DIFF
--- a/Tests/Functional/Command/CreateTestDataCommandTest.php
+++ b/Tests/Functional/Command/CreateTestDataCommandTest.php
@@ -15,9 +15,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 #[CoversClass(CreateTestDataCommand::class)]
 final class CreateTestDataCommandTest extends FunctionalTestCase
 {
-    /**
-     * @var non-empty-string
-     */
     private const COMMAND_NAME = 'tea:create-test-data';
 
     protected array $testExtensionsToLoad = ['ttn/tea'];

--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -15,13 +15,8 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestCon
 #[CoversClass(FrontEndEditorController::class)]
 final class FrontEndEditorControllerTest extends AbstractFrontendControllerTestCase
 {
-    /** @var positive-int */
     private const UID_OF_PAGE = 1;
-
-    /** @var positive-int */
     private const UID_OF_TEA = 1;
-
-    /** @var array<non-empty-string, 1> */
     private const TRUSTED_PROPERTIES = [
         'title' => 1,
         'description' => 1,


### PR DESCRIPTION
It has turned out that PHPStan does not need them.

Fixes #1885