### PR TITLE
[BUGFIX] Work around bug with symfony/dependency-injection 7.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
 		"typo3-ter/tea": "self.version"
 	},
 	"conflict": {
+		"symfony/dependency-injection": "7.4.0",
 		"typo3/class-alias-loader": "< 1.1.0"
 	},
 	"prefer-stable": true,


### PR DESCRIPTION
symfony/dependency-injection 7.4.0 introduced a
backwards-imcompatible change that triggered PHP errors with the current versions of TYPO3 12LTS and 13LTS.

Until the bug is fixed in symfony/dependency-injection or until the workarounds in the TYPO3 Core are released, we need to avoid installing symfony/dependency-injection 7.4.0.

https://github.com/symfony/symfony/pull/62544
https://review.typo3.org/c/Packages/TYPO3.CMS/+/91926