### PR TITLE
[TASK] Drop obsolete package conflict from `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,8 +78,7 @@
 		"typo3-ter/tea": "self.version"
 	},
 	"conflict": {
-		"symfony/dependency-injection": "7.4.0",
-		"typo3/class-alias-loader": "< 1.1.0"
+		"symfony/dependency-injection": "7.4.0"
 	},
 	"prefer-stable": true,
 	"autoload": {


### PR DESCRIPTION
This conflict is no longer needed now that we don't support TYPO3 11LTS anymore.