### PR TITLE
[CLEANUP] Drop obsolete Composer plugin allowlisting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,6 @@
 		"allow-plugins": {
 			"ergebnis/composer-normalize": true,
 			"phpstan/extension-installer": true,
-			"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": true,
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true
 		},


### PR DESCRIPTION
With recent versions of the TYPO3 testing framework available, we're not using the package anymore for which a Composer plugin is configured.