### PR TITLE
[TASK] Allow symfony/dependency-injection 7.4.0 again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,9 +77,6 @@
 	"replace": {
 		"typo3-ter/tea": "self.version"
 	},
-	"conflict": {
-		"symfony/dependency-injection": "7.4.0"
-	},
 	"prefer-stable": true,
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Now that the lastest versions of TYPO3 12LTS and 13LTS work fine with symfony/dependency-injection 7.4.0, we can allow that version again.

https://review.typo3.org/c/Packages/TYPO3.CMS/+/91926