### PR TITLE
[DOCS] Update URLs of the moved team page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ You can also use this extension to manage your collection of delicious teas.
 
 We value and welcome feedback of all kinds, including discussions.
 Feedback can be sent via TYPO3 slack within [our channel](https://app.slack.com/client/T024TUMLZ/CSQ8T0VS5) or via direct massages to the team members.
-We also welcome email. All the contact information is available at our [typo3.org team page](https://typo3.org/community/teams/best-practices).
+We also welcome email. All the contact information is available at our
+[team page](https://typo3.community/contribute/teams-committees/best-practices).
 Another way is to create a [discussion on GitHub](https://github.com/TYPO3BestPractices/tea/discussions).
 
 ## Philosophies
 
-The following is a list of our code and technical philosophies only.
-https://typo3.org/community/teams/best-practices provides an overview on how we work in general.
+The following is a list of our code and technical philosophies only. Our
+[team page](https://typo3.community/contribute/teams-committees/best-practices)
+provides an overview on how we work in general.
 
 ### Semantic Versioning
 


### PR DESCRIPTION
Our team page now resides at typo3.community. Hence, we need to update the URL in the documentation.