### PR TITLE
[BUGFIX] Fix SQLite functional tests with Docker on WSL2

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -505,11 +505,14 @@ shift $((OPTIND - 1))
 ${CONTAINER_BIN} network create ${NETWORK} >/dev/null
 
 if [ "${CONTAINER_BIN}" == "docker" ]; then
+    # docker needs the add-host for xdebug remote debugging. podman has host.container.internal built in
     CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host "${CONTAINER_HOST}:host-gateway" ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
+    TMPFS_MOUNT_OPTIONS="rw,noexec,nosuid,uid=${HOST_UID},gid=${HOST_PID}"
 else
     # podman
     CONTAINER_HOST="host.containers.internal"
     CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
+    TMPFS_MOUNT_OPTIONS="rw,noexec,nosuid"
 fi
 
 if [ ${PHP_XDEBUG_ON} -eq 0 ]; then


### PR DESCRIPTION
SQLite functional tests failed with "unable to open database file" because the container user had no permission to write to the tmpfs mount directory. Adding uid/gid options to the tmpfs mount fixes this.

This is a copy of the corresponding change from the TYPO3 Core `runTests.sh`:

https://review.typo3.org/c/Packages/TYPO3.CMS/+/92388

Fixes #1925