### PR TITLE
[TASK] Make Composer cache keys for CI more readable

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -39,9 +39,9 @@ jobs:
       - name: Cache dependencies installed with composer
         uses: actions/cache@v5
         with:
-          key: "php${{ matrix.php-version }}-typo3${{ matrix.typo3-version }}-${{ matrix.composer-dependencies }}-composer-${{ hashFiles('**/composer.json') }}"
+          key: "php-${{ matrix.php-version }}-typo3-${{ matrix.typo3-version }}-${{ matrix.composer-dependencies }}-composer-${{ hashFiles('**/composer.json') }}"
           path: ~/.cache/composer
-          restore-keys: "php${{ matrix.php-version }}-typo3${{ matrix.typo3-version }}-${{ matrix.composer-dependencies }}-composer-\n"
+          restore-keys: "php-${{ matrix.php-version }}-typo3-${{ matrix.typo3-version }}-${{ matrix.composer-dependencies }}-composer-\n"
       - name: Install TYPO3 Core
         env:
           TYPO3: "${{ matrix.typo3-version }}"


### PR DESCRIPTION
- `php8.3` -> `php-8.3`
- `typo312.4` -> `typo3-12.4`