### PR TITLE
[BUGFIX] Fix parameter type in the Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     cooldown:
-      default-days: "21"
+      default-days: 21
     schedule:
       interval: "daily"
     versioning-strategy: "increase"


### PR DESCRIPTION
The number of days for the cooldown period needs to be an integer, and passing a string breaks Dependabot.