### PR TITLE
[TASK] Drop redundant assignment in `runTests.sh`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -563,7 +563,6 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     composerNormalize)
-        COMMAND="composer check:composer:normalize"
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
             COMMAND="composer check:composer:normalize"
         else


### PR DESCRIPTION
The assign variable is overwritten in all branches of the following condition.

Fixes #1959