### PR TITLE
[TASK] Use one command to execute all fixers in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
         run: ./Build/Scripts/runTests.sh -s composer config --global --list
       - name: Install Composer dependencies
         run: Build/Scripts/runTests.sh -s composerUpdateMax
-      - name: Run composer normalize check fixer
-        run: Build/Scripts/runTests.sh -s fixComposerNormalize
+      - name: Runs all automatic code style fixes.
+        run: Build/Scripts/runTests.sh -s fix
   prepare-release:
     name: Check prepare release script
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Usage of one `fix` command to execute all fixers by `runScript.sh`

Related: #1855, #1975