### PR TITLE
[TASK] Update and pin the container images in `runTests.sh`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -493,9 +493,9 @@ mkdir -p .Build/public/typo3temp/var/tests
 
 IMAGE_PHP="ghcr.io/typo3/core-testing-$(echo "php${PHP_VERSION}" | sed -e 's/\.//'):latest"
 IMAGE_NODE="docker.io/node:${NODE_VERSION}-alpine"
-IMAGE_ALPINE="docker.io/alpine:3.8"
+IMAGE_ALPINE="docker.io/alpine:3.23.3"
 IMAGE_SHELLCHECK="docker.io/koalaman/shellcheck:v0.11.0"
-IMAGE_DOCS="ghcr.io/typo3-documentation/render-guides:latest"
+IMAGE_DOCS="ghcr.io/typo3-documentation/render-guides:0.36.0"
 IMAGE_MARIADB="docker.io/mariadb:${DBMS_VERSION}"
 IMAGE_MYSQL="docker.io/mysql:${DBMS_VERSION}"
 IMAGE_POSTGRES="docker.io/postgres:${DBMS_VERSION}-alpine"


### PR DESCRIPTION
This ensures that new releases of the images won't break our build.

The downside is that we'll need to update the image versions manually.

For images that have variable versions (PHP, DBMS, Node.js),we still don't use fixed point releases as it cannot be assured that specific point releases exist that match the variable part.