### PR TITLE
[TASK] Move shellcheck suppression from environment variables to runTests.sh

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2086,SC2046,SC2128
 
 # Uncomment for debugging
 # set -x
@@ -593,7 +594,7 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     shellcheck)
-        ${CONTAINER_BIN} run ${CONTAINER_INTERACTIVE} --rm --pull always ${USERSET} -v "${ROOT_DIR}":/project:ro -e SHELLCHECK_OPTS="-e SC2086,SC2046,SC2128" ${IMAGE_SHELLCHECK} /project/Build/Scripts/runTests.sh
+        ${CONTAINER_BIN} run ${CONTAINER_INTERACTIVE} --rm --pull always ${USERSET} -v "${ROOT_DIR}":/project:ro ${IMAGE_SHELLCHECK} /project/Build/Scripts/runTests.sh
         SUITE_EXIT_CODE=$?
         ;;
     functional)


### PR DESCRIPTION
This way we can have own scripts with stricter checks, when needed. 

Relates: #1841