### PR TITLE
[TASK] Streamline the Rector configuration

### DIFF
--- a/Build/rector/config.php
+++ b/Build/rector/config.php
@@ -2,13 +2,9 @@
 
 declare(strict_types=1);
 
-use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
-use Rector\CodeQuality\Rector\Ternary\SwitchNegatedTernaryRector;
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
-use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 use Rector\ValueObject\PhpVersion;
 use Ssch\TYPO3Rector\CodeQuality\General\ConvertImplicitVariablesToExplicitGlobalsRector;
@@ -16,10 +12,10 @@ use Ssch\TYPO3Rector\CodeQuality\General\ExtEmConfRector;
 use Ssch\TYPO3Rector\Configuration\Typo3Option;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 use Ssch\TYPO3Rector\Set\Typo3SetList;
-use Ssch\Typo3RectorTestingFramework\Set\TYPO3TestingFrameworkSetList;
 
 return RectorConfig::configure()
     ->withPaths([
+        __DIR__ . '/../../Build/',
         __DIR__ . '/../../Classes/',
         __DIR__ . '/../../Configuration/',
         __DIR__ . '/../../Tests/',
@@ -27,29 +23,14 @@ return RectorConfig::configure()
         __DIR__ . '/../../ext_localconf.php',
     ])
     ->withPhpVersion(PhpVersion::PHP_81)
-    ->withPhpSets(
-        true
-    )
-    // Note: We're only enabling a single set by default to improve performance. (Rector needs at least a single set to
-    // run.)
-    //
-    // You can temporarily enable more sets as needed.
+    ->withPhpSets()
     ->withSets([
         // Rector sets
 
-        // LevelSetList::UP_TO_PHP_53,
-        // LevelSetList::UP_TO_PHP_54,
-        // LevelSetList::UP_TO_PHP_55,
-        // LevelSetList::UP_TO_PHP_56,
-        // LevelSetList::UP_TO_PHP_70,
-        // LevelSetList::UP_TO_PHP_71,
-        // LevelSetList::UP_TO_PHP_72,
-        // LevelSetList::UP_TO_PHP_73,
-        // LevelSetList::UP_TO_PHP_74,
-        // LevelSetList::UP_TO_PHP_80,
-        // LevelSetList::UP_TO_PHP_81,
+        LevelSetList::UP_TO_PHP_81,
         // LevelSetList::UP_TO_PHP_82,
         // LevelSetList::UP_TO_PHP_83,
+        // LevelSetList::UP_TO_PHP_84,
 
         // SetList::CODE_QUALITY,
         // SetList::CODING_STYLE,
@@ -63,8 +44,8 @@ return RectorConfig::configure()
 
         // PHPUnit sets
 
-        // PHPUnitSetList::PHPUNIT80_DMS,
         PHPUnitSetList::PHPUNIT_100,
+        // PHPUnitSetList::PHPUNIT_110,
         // PHPUnitSetList::PHPUNIT_CODE_QUALITY,
 
         // TYPO3 Sets
@@ -75,8 +56,7 @@ return RectorConfig::configure()
         Typo3SetList::GENERAL,
 
         Typo3LevelSetList::UP_TO_TYPO3_12,
-
-        // TYPO3TestingFrameworkSetList::TYPO3_TESTING_FRAMEWORK_7,
+        // Typo3LevelSetList::UP_TO_TYPO3_13,
     ])
     // To have a better analysis from PHPStan, we teach it here some more things
     ->withPHPStanConfigs([


### PR DESCRIPTION
- drop commented-out configuration sets for lower PHP versions
- add commented-out configuration sets for higher PHP and TYPO3 versions
- always use the PHP version from `composer.json` instead of providing a PHP version to `withPhpSets()`
- enable the PHP set by default as Rector nowadays is fast enough
- drop irrelevant configuration sets
- add `Build/` to the paths to migrate/check