### PR TITLE
[TASK] Replace direct Docker call with script for documentation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,5 +208,4 @@ jobs:
         uses: actions/checkout@v6
       - name: Test if the documentation will render without warnings
         run: |
-          docker run --rm --pull always -v $(pwd):/project \
-             ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --fail-on-log
+          Build/Scripts/runTests.sh -s docsGenerate


### PR DESCRIPTION
Switched from inline Docker command to `Build/Scripts/runTests.sh -s docsGenerate` for documentation rendering tests.

Resolves: #2030