### PR TITLE
Move PHPUnit Rector config to Composer

### DIFF
--- a/Build/rector/config.php
+++ b/Build/rector/config.php
@@ -19,6 +19,7 @@ return RectorConfig::configure()
         __DIR__ . '/../../ext_localconf.php',
     ])
     ->withPhpSets()
+    ->withComposerBased(phpunit: true)
     ->withSets([
         // Rector sets
 
@@ -31,12 +32,6 @@ return RectorConfig::configure()
         // SetList::PRIVATIZATION,
         // SetList::STRICT_BOOLEANS,
         // SetList::TYPE_DECLARATION,
-
-        // PHPUnit sets
-
-        PHPUnitSetList::PHPUNIT_100,
-        // PHPUnitSetList::PHPUNIT_110,
-        // PHPUnitSetList::PHPUNIT_CODE_QUALITY,
 
         // TYPO3 Sets
         // https://github.com/sabbelasichon/typo3-rector/blob/main/src/Set/Typo3LevelSetList.php


### PR DESCRIPTION
This PR moves the set configuration for PHPUnit from explicit naming of sets to derivation from `composer.json`.
This needs at least rector 2.0 so we decided to avoid trying to raise the version under TYPO3 12.4 and wait for that version to drop out of support.
#2034 