### PR TITLE
[TASK] Set the `main` Composer alias down to 4.1.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-main": "5.0.x-dev"
+			"dev-main": "4.1.x-dev"
 		},
 		"typo3/cms": {
 			"extension-key": "tea",


### PR DESCRIPTION
We're not going to have the breaking release 5.0.0 next, but will have (at least) a 4.1.0 release first.