### PR TITLE
[TASK] Use the full CI matrix for the code quality jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,9 @@ jobs:
         run: ./Build/Scripts/runTests.sh -s composer -- --version
       - name: Show the Composer configuration
         run: ./Build/Scripts/runTests.sh -s composer config --global --list
-      - name: Install Composer dependencies
-        run: Build/Scripts/runTests.sh -s composerUpdateMax
+      - name: Install composer dependencies
+        run: |
+          ./Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -t ${{matrix.typo3-version}} -s composerUpdate${{matrix.composer-dependencies}}
       - name: Run code quality checks
         run: |
           Build/Scripts/runTests.sh -s composer check:${{ matrix.command }}
@@ -70,6 +71,14 @@ jobs:
           - "typoscript:lint"
           - "xliff:lint"
           - "yaml:lint"
+        # For consistency, the PHP version should match the default PHP version in `runTests.sh`.
+        php-version:
+          - "8.2"
+        # For consistency, the TYPO3 version should match the default TYPO3 version in `runTests.sh`.
+        typo3-version:
+          - "13.4"
+        composer-dependencies:
+          - Max
   static-code-analysis:
     name: Static code quality checks
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This makes the jobs more consistent with each other and prepares the CI pipelines for Composer caching.

Relates: #1954