### PR TITLE
[BUGFIX] Add missing coverage attribute

### DIFF
--- a/Tests/Functional/Upgrades/ListTypeToCTypeUpdateTest.php
+++ b/Tests/Functional/Upgrades/ListTypeToCTypeUpdateTest.php
@@ -10,6 +10,7 @@ use TTN\Tea\Upgrades\AbstractListTypeToCTypeUpdate;
 use TTN\Tea\Upgrades\ListTypeToCTypeUpdate;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
+#[CoversClass(AbstractListTypeToCTypeUpdate::class)]
 #[CoversClass(ListTypeToCTypeUpdate::class)]
 final class ListTypeToCTypeUpdateTest extends FunctionalTestCase
 {


### PR DESCRIPTION
The functional test for the upgrade wizard also tests the superclass. Model this as a coverage attribute.