### PR TITLE
[TASK] Use the full CI matrix for the static analysis jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           ./Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -t ${{matrix.typo3-version}} -s composerUpdate${{matrix.composer-dependencies}}
       - name: Run code quality checks
         run: |
-          Build/Scripts/runTests.sh -s composer check:${{ matrix.command }}
+          Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composer check:${{ matrix.command }}
     strategy:
       fail-fast: false
       matrix:
@@ -89,17 +89,26 @@ jobs:
         run: ./Build/Scripts/runTests.sh -s composer -- --version
       - name: Show the Composer configuration
         run: ./Build/Scripts/runTests.sh -s composer config --global --list
-      - name: Install Composer dependencies
-        run: Build/Scripts/runTests.sh -s composerUpdateMax
+      - name: Install composer dependencies
+        run: |
+          ./Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -t ${{matrix.typo3-version}} -s composerUpdate${{matrix.composer-dependencies}}
       - name: Run code quality checks
         run: |
-          Build/Scripts/runTests.sh -s ${{ matrix.command }}
+          Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s ${{ matrix.command }}
     strategy:
       fail-fast: false
       matrix:
         command:
           - "phpmd"
           - "checkComposerNormalize"
+        # For consistency, the PHP version should match the default PHP version in `runTests.sh`.
+        php-version:
+          - "8.2"
+        # For consistency, the TYPO3 version should match the default TYPO3 version in `runTests.sh`.
+        typo3-version:
+          - "13.4"
+        composer-dependencies:
+          - Max
   check-fixers:
     name: Check fixers
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This makes the jobs more consistent with each other and prepares the CI pipelines for Composer caching.

Also explicitly pass the PHP version to `runTests.sh` in the code quality job (which was missing from #2083).

Relates: #1954