### PR TITLE
[BUGFIX] Use a lower TYPO3 version for PHP linting with 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version:
-          - "8.1"
-          - "8.2"
-          - "8.3"
-          - "8.4"
-          - "8.5"
-        # For consistency, the TYPO3 version should match the default TYPO3 version in `runTests.sh`.
-        typo3-version:
-          - "13.4"
-        composer-dependencies:
-          - Max
+        include:
+          - typo3-version: "12.4"
+            php-version: "8.1"
+            composer-dependencies: Max
+          - typo3-version: "13.4"
+            php-version: "8.2"
+            composer-dependencies: Max
+          - typo3-version: "13.4"
+            php-version: "8.3"
+            composer-dependencies: Max
+          - typo3-version: "13.4"
+            php-version: "8.4"
+            composer-dependencies: Max
+          - typo3-version: "13.4"
+            php-version: "8.5"
+            composer-dependencies: Max
   code-quality:
     name: Code quality checks
     runs-on: ubuntu-24.04


### PR DESCRIPTION
We cannot install a working set of Composer packages with TYPO3 V13 and PHP 8.1. So include the TYPO3 version into the CI matrix for the PHP linting CI job.