### PR TITLE
[TASK] Switch the code coverage CI job to TYPO3 V13

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -90,6 +90,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - typo3-version: "12.4"
-            php-version: "8.3"
+          - typo3-version: "13.4"
+            php-version: "8.2"
             composer-dependencies: Max


### PR DESCRIPTION
For consistency, also use `runTests.sh`'s default PHP version 8.2.