### PR TITLE
[CLEANUP] Move `check:php:lint` before `check:php:cs-fixer` in Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -135,8 +135,8 @@
 		],
 		"check:json:lint": "find . ! -path '*/.cache/*' ! -path '*/.Build/*' ! -path '*/node_modules/*' -name '*.json' | xargs -r php .Build/bin/jsonlint -q",
 		"check:php": [
-			"@check:php:cs-fixer",
 			"@check:php:lint",
+			"@check:php:cs-fixer",
 			"@check:php:stan"
 		],
 		"check:php:cs-fixer": "php-cs-fixer fix --config ./Build/php-cs-fixer/config.php -v --dry-run --diff",


### PR DESCRIPTION
When checking the code, the PHP linting always needs to come before other PHP-related checkers (PHP-CS-Fixer, Rector, PHPStan, PHP_CodeSniffer) as there's no point in checking anything else if the PHP is not valid.