### PR TITLE
[DOCS] Rename the CI workflow and drop a deprecated comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 ---
-# This GitHub Actions workflow uses the same development tools that are also installed locally
-# via Composer or PHIVE and calls them using the Composer scripts.
-name: GitHub Actions CI
+name: CI
 on:
   push:
     branches:


### PR DESCRIPTION
Now that we don't have a GitLab CI workflow, there is no need to mention in the CI workflow name that it's using GitHub Actions.