### PR TITLE
[TASK] Undo NPM/Node.js version requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
 				"stylelint-no-browser-hacks": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=24.14.1 <25.0.0",
-				"npm": ">=11.11.0"
+				"node": "^20.17.0 || ^22.5.1",
+				"npm": "^9.6.5 || ^10.8.2"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 	"version": "1.0.0",
 	"license": "GPL-2.0-or-later",
 	"engines": {
-		"node": ">=24.14.1 <25.0.0",
-		"npm": ">=11.11.0"
+		"node": ">=24.14.0 <25.0.0",
+		"npm": ">=11.9.0"
 	},
 	"scripts": {
 		"check:lint:js": "eslint --config ./Build/eslint/eslint.config.js 'Resources/Public/**/*.js'",


### PR DESCRIPTION
The change did not help with Dependabot updates and should be reverted.

This reverts commit 21b5ae6345efd7bc363c626701f781213cdbc254.