### PR TITLE
[FEATURE] Add MariaDB to the functional tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,10 @@ jobs:
             composer-dependencies: Min
           - typo3-version: "12.4"
             php-version: "8.5"
+            dbms: "mariadb"
+            composer-dependencies: Max
+          - typo3-version: "12.4"
+            php-version: "8.5"
             dbms: "mysql"
             composer-dependencies: Max
           - typo3-version: "12.4"
@@ -307,6 +311,10 @@ jobs:
           - typo3-version: "13.4"
             php-version: "8.5"
             dbms: "sqlite"
+            composer-dependencies: Max
+          - typo3-version: "13.4"
+            php-version: "8.5"
+            dbms: "mariadb"
             composer-dependencies: Max
           - typo3-version: "13.4"
             php-version: "8.5"


### PR DESCRIPTION
The functional tests on CI ran against SQLite, MySQL and PostgreSQL,
but never against MariaDB, although `runTests.sh` supports it.

Functional test jobs for TYPO3 13.4 and 14.3 with PHP 8.5 and the
highest dependencies now runs against MariaDB 10.4, the default
MariaDB version of `runTests.sh`.

The job failed while `runTests.sh` used podman on the GitHub hosted
runners, where the MariaDB container never became reachable. Since
the CI containers run with docker (#2322), the job passes.

Resolves: #2103
Related: #2321