### PR TITLE
[CLEANUP] Move and rename the basic tests

### DIFF
--- a/Tests/Functional/ExtensionLoadedTest.php
+++ b/Tests/Functional/ExtensionLoadedTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TTN\Tea\Tests\Functional\Environment;
+namespace TTN\Tea\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
@@ -10,16 +10,17 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 #[CoversNothing]
-final class ExtensionTest extends FunctionalTestCase
+final class ExtensionLoadedTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = ['ttn/tea'];
+
     protected bool $initializeDatabase = false;
 
     #[Test]
     public function isLoaded(): void
     {
         self::assertTrue(
-            ExtensionManagementUtility::isLoaded('tea')
+            ExtensionManagementUtility::isLoaded('tea'),
         );
     }
 }

--- a/Tests/Unit/VersionCompatibilityTest.php
+++ b/Tests/Unit/VersionCompatibilityTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TTN\Tea\Tests\Unit\Environment;
+namespace TTN\Tea\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 #[CoversNothing]
-final class ExtensionTest extends UnitTestCase
+final class VersionCompatibilityTest extends UnitTestCase
 {
     #[Test]
     public function currentVersionIsSupported(): void
@@ -19,7 +19,7 @@ final class ExtensionTest extends UnitTestCase
         $currentVersion = (new Typo3Version())->getMajorVersion();
         self::assertContains(
             $currentVersion,
-            $supportedVersions
+            $supportedVersions,
         );
     }
 }


### PR DESCRIPTION
Move them to the unit/functional tests roots to make them more discoverable.