### PR TITLE
[TASK] Do not process `Build/` with Rector

### DIFF
--- a/Build/rector/config.php
+++ b/Build/rector/config.php
@@ -12,7 +12,6 @@ use Ssch\TYPO3Rector\Set\Typo3SetList;
 
 return RectorConfig::configure()
     ->withPaths([
-        __DIR__ . '/../../Build/',
         __DIR__ . '/../../Classes/',
         __DIR__ . '/../../Configuration/',
         __DIR__ . '/../../Tests/',


### PR DESCRIPTION
Rector should not try to modify its own configuration as this can become messy. (Also, it usually cannot change anything meaningful there anyway.)