### PR TITLE
[TASK] Disable some Type Perfect PHPStan rules

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -11,9 +11,3 @@ parameters:
 			identifier: missingType.generics
 			count: 1
 			path: ../../Classes/Domain/Repository/TeaRepository.php
-
-		-
-			rawMessage: Provide more specific return type "TYPO3\CMS\Extbase\Persistence\QueryResultInterface" over abstract one
-			identifier: typePerfect.narrowReturnObjectType
-			count: 2
-			path: ../../Classes/Domain/Repository/TeaRepository.php

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -29,8 +29,8 @@ parameters:
     no_mixed_property: true
     no_mixed_caller: true
     null_over_false: true
-    narrow_param: true
-    narrow_return: true
+    narrow_param: false
+    narrow_return: false
 
   disallowedFunctionCalls:
     -


### PR DESCRIPTION
The `narrow_param` and `narrow_return` rules don't work well with Extbase generics and with nullable properties. Hence they create false positives.

Disable them.