### PR TITLE
[TASK] Allow TTY/non-interactive detection in runTests.sh

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -478,9 +478,15 @@ fi
 
 handleDbmsOptions
 
-# ENV var "CI" is set by gitlab-ci. Use it to force some CI details.
 if [ "${CI}" == "true" ]; then
+    # ENV var "CI" is set by gitlab-ci. Use it to force some CI details.
     CONTAINER_INTERACTIVE=""
+elif [ ! -t 0 ] || [ ! -t 1 ]; then
+    # If stdin or stdout is not a TTY (e.g. a script runner, pipe, or non-interactive shell),
+    # drop the interactive "-it" flags automatically to avoid podman warning "The input device
+    # is not a TTY." and docker failure, and to keep redirected output free of TTY control characters.
+    # Keep "--init" so the PID 1 init process still forwards signals (e.g. ctrl-c) to the test process.
+    CONTAINER_INTERACTIVE="--init"
 fi
 
 # determine default container binary to use: 1. podman 2. docker


### PR DESCRIPTION
The `runTests.sh` dispatcher can now auto-detect if it is
run inside a non-interactive environment (like sandboxed
coding agents, CI): The patch checks stdin and stdout for
an attached terminal and avoids the '-it' argument to
podman/docker to prevent warnings (podman), failures (docker)
and cluttered redirected output. '--init' is kept to retain
CTRL+C (SIGINT) handling in container PID 1.

https://review.typo3.org/c/Packages/TYPO3.CMS/+/94162

Fixes #2142