### PR TITLE
[TASK] Allow insecure and abandoned Composer packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,10 @@
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true
 		},
+		"audit": {
+			"block-insecure": false,
+			"block-abandoned": false
+		},
 		"bin-dir": ".Build/bin",
 		"lock": false,
 		"preferred-install": {


### PR DESCRIPTION
The Composer functionality for blocking insecure and abandoned packages only makes sense for projects, not for libraries or TYPO3 extensions.

Also, blocking insecure packages also blocks us from installing TYPO3 12LTS (as the public version has known vulnerabilities).

To fix our CI pipeline, we need to configure Composer to allow insecure and abandoned packages.

```
composer config audit.block-insecure false
composer config audit.block-abandoned false
composer normalize
```