### PR TITLE
[TASK] Update most GitHub Action runners to Ubuntu 26.04

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -11,7 +11,7 @@ jobs:
   auto-approve:
     name: Dependabot auto-approve
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     if: ${{ github.actor == 'dependabot[bot]' }}
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ jobs:
   auto-merge:
     name: Dependabot auto-merge
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     if: ${{ github.actor == 'dependabot[bot]' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   php-lint:
     name: PHP linter
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -53,7 +53,7 @@ jobs:
             composer-dependencies: Max
   phpstan:
     name: PHPStan code quality checks
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -85,7 +85,7 @@ jobs:
             composer-dependencies: Max
   code-quality:
     name: Code quality checks
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -127,7 +127,7 @@ jobs:
           - Max
   static-code-analysis:
     name: Static code quality checks
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -163,7 +163,7 @@ jobs:
           - Max
   check-fixers:
     name: Check fixers
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -195,7 +195,7 @@ jobs:
           - Max
   prepare-release:
     name: Check prepare release script
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -208,7 +208,7 @@ jobs:
           - "8.3"
   code-quality-frontend:
     name: Code quality frontend checks
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:
@@ -223,7 +223,7 @@ jobs:
           Build/Scripts/runTests.sh -s lint${{ matrix.command }}
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: php-lint
     steps:
       - name: Checkout
@@ -274,7 +274,7 @@ jobs:
             composer-dependencies: Max
   functional-tests:
     name: Functional tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: php-lint
     steps:
       - name: Checkout
@@ -349,7 +349,7 @@ jobs:
             composer-dependencies: Max
   shellcheck:
     name: Check shell scripts
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 2
     steps:
       - name: Checkout
@@ -359,7 +359,7 @@ jobs:
           Build/Scripts/runTests.sh -s shellcheck
   documentation:
     name: Documentation
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 2
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
   publish:
     permissions:
       actions: write
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
For the code coverage workflow (which does not use `runTests.sh` yet), we stay at 24.04 as the Ubuntu 26.04 GitHub Actions runner does not provide MySQL out of the box anymore.

We'll update to 26.04 after we've switch the code coverage CI workflow to use `runTests.sh`.