### PR TITLE
[TASK] Update to `typo3/coding-standards` 0.9.0

### DIFF
--- a/Build/php-cs-fixer/config.php
+++ b/Build/php-cs-fixer/config.php
@@ -8,14 +8,5 @@ $config = CsFixerConfig::create();
 // @TODO 4.0 no need to call this manually
 $config->setParallelConfig(ParallelConfigFactory::detect());
 
-$config->addRules(
-    [
-        'native_function_invocation' => [
-            'include' => [],
-            'scope' => 'all',
-            'strict' => true,
-        ],
-    ],
-);
 $config->getFinder()->in('Classes')->in('Configuration')->in('Tests');
 return $config;

--- a/Configuration/TCA/tx_tea_domain_model_tea.php
+++ b/Configuration/TCA/tx_tea_domain_model_tea.php
@@ -24,8 +24,8 @@ return [
     ],
     'types' => [
         '1' => [
-            'showitem' =>
-                '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
+            'showitem'
+                => '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     title, description, image, owner,
                  --div--;LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.tabs.access,
                     --palette--;;hidden,
@@ -109,8 +109,8 @@ return [
                     ],
                 ],
                 'foreign_table' => 'tx_tea_domain_model_tea',
-                'foreign_table_where' =>
-                    'AND {#tx_tea_domain_model_tea}.{#pid}=###CURRENT_PID###
+                'foreign_table_where'
+                    => 'AND {#tx_tea_domain_model_tea}.{#pid}=###CURRENT_PID###
                      AND {#tx_tea_domain_model_tea}.{#sys_language_uid} IN (-1,0)',
                 'default' => 0,
             ],

--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -17,6 +17,9 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 #[CoversClass(FrontEndEditorController::class)]
 final class FrontEndEditorControllerTest extends FunctionalTestCase
 {
+    private const UID_OF_PAGE = 1;
+    private const UID_OF_TEA = 1;
+
     protected array $testExtensionsToLoad = ['ttn/tea'];
 
     protected array $coreExtensionsToLoad = ['typo3/cms-fluid-styled-content'];
@@ -32,9 +35,6 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
             ],
         ],
     ];
-
-    private const UID_OF_PAGE = 1;
-    private const UID_OF_TEA = 1;
 
     protected function setUp(): void
     {

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
 		"tomasvotruba/cognitive-complexity": "0.2.3 || 1.1.1",
 		"tomasvotruba/type-coverage": "1.0.0 || 2.2.1",
 		"typo3/cms-fluid-styled-content": "^13.4",
-		"typo3/coding-standards": "0.8.0",
+		"typo3/coding-standards": "0.9.0",
 		"typo3/testing-framework": "8.3.1"
 	},
 	"replace": {


### PR DESCRIPTION
The new version includes the rule which we have had as a custom rule so far, allowing us to drop it.

https://github.com/TYPO3/coding-standards/releases/tag/v0.9.0

```
composer req --dev typo3/coding-standards:0.9.0
./Build/Scripts/runTests.sh -s cgl
```