### PR TITLE
[BUGFIX] Fix the main label for the BE module

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -11,7 +11,9 @@ return [
         'access' => 'user',
         'workspaces' => 'live',
         'path' => '/module/tea/index',
-        'labels' => 'LLL:EXT:tea/Resources/Private/Language/locallang_index_mod.xlf',
+        'labels' => [
+            'title' => 'LLL:EXT:tea/Resources/Private/Language/locallang_index_mod.xlf:module.title',
+        ],
         'extensionName' => 'Tea',
         'iconIdentifier' => 'tx-tea-backend-module',
         'inheritNavigationComponentFromMainModule' => false,


### PR DESCRIPTION
Use the explicit syntax, refer to an existing language file, and use an explicit label key.

https://docs.typo3.org/permalink/t3coreapi:backend-modules-configuration-options