### PR TITLE
[CLEANUP] Always call `parent::setUp()` first in `setUp()`

### DIFF
--- a/Tests/Functional/Controller/BackendModuleControllerTest.php
+++ b/Tests/Functional/Controller/BackendModuleControllerTest.php
@@ -30,12 +30,10 @@ final class BackendModuleControllerTest extends FunctionalTestCase
 
     private const FORM_PROTECTION_SESSION_TOKEN = 'testToken';
 
+    protected array $testExtensionsToLoad = ['ttn/tea'];
+
     protected function setUp(): void
     {
-        $this->testExtensionsToLoad = [
-            'ttn/tea',
-        ];
-
         parent::setUp();
 
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/BackendModuleController/BackendUser.csv');


### PR DESCRIPTION
This is a best practice, and there should be no exceptions.