### PR TITLE
[DOCS] Change composer command to use `runTests.sh` to run all fixers

### DIFF
--- a/Documentation/TechnicalBackground/Running.rst
+++ b/Documentation/TechnicalBackground/Running.rst
@@ -118,10 +118,10 @@ Lints the TypoScript files.
 
 Lints the YAML files.
 
-.. index:: Commands; composer fix
+.. index:: Commands; fix
 .. code-block:: bash
 
-    ./Build/Scripts/runTests.sh -s composer fix
+    ./Build/Scripts/runTests.sh -s fix
 
 Runs all fixers (except for the ones that need JavaScript).
 


### PR DESCRIPTION
Related: #1855

If I see that right https://github.com/TYPO3BestPractices/tea/issues/1855#issuecomment-4370244102 the `fix` command in the documentation should be changed.
The fix command is now complete.