### PR TITLE
[TASK] Use dry-run mode when running fixers as checkers on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
           ./Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -t ${{matrix.typo3-version}} -s composerUpdate${{matrix.composer-dependencies}}
       - name: Run code quality checks
         run: |
-          Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s ${{ matrix.command }}
+          Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -n -s ${{ matrix.command }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -136,7 +136,7 @@ jobs:
           ./Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -t ${{matrix.typo3-version}} -s composerUpdate${{matrix.composer-dependencies}}
       - name: Run code quality checks
         run: |
-          Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s ${{ matrix.command }}
+          Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -n -s ${{ matrix.command }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
When we switch the `runTests.sh` commands to be dual-usable as fixers and checkers, we need to make sure we run them in dry-run mode on CI.