### PR TITLE
[TASK] Remove composerNormalize option from help

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -192,7 +192,6 @@ Options:
             - cleanRenderedDocumentation: clean up rendered documentation files and folders (Documentation-GENERATED-temp)
             - cleanTests: clean up test related files and folders
             - composer: "composer" with all remaining arguments dispatched.
-            - composerNormalize: Normalizes the composer.json.
             - composerUnused: Finds unused Composer packages.
             - composerUpdateMax: "composer update", with no platform.php config.
             - composerUpdateMin: "composer update --prefer-lowest", with platform.php set to PHP version x.x.0.


### PR DESCRIPTION
The help text listed composerNormalize as an available option, but it was not implemented in the script. Removed to avoid confusion.

Relates: #2052