### PR TITLE
[TASK] Use autogenerated SQL columns as much as possible

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,8 +1,0 @@
-CREATE TABLE tx_tea_domain_model_tea (
-    title       varchar(255)     DEFAULT ''  NOT NULL,
-    description varchar(2000)    DEFAULT ''  NOT NULL,
-    image       int(11) unsigned DEFAULT '0' NOT NULL,
-    owner       int(11) unsigned DEFAULT '0' NOT NULL,
-
-    KEY owner (owner)
-);


### PR DESCRIPTION
Starting with TYPO3 13LTS, TYPO3 can autogenerate most of the SQL for a table from TCA.