### PR TITLE
[BUGFIX] Allow the `composerNormalize` command to fix things

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -655,11 +655,10 @@ case ${TEST_SUITE} in
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
         SUITE_EXIT_CODE=$?
         ;;
-     composerNormalize)
-         CGLCHECK_DRY_RUN="-n"
-         composerNormalize
-         SUITE_EXIT_CODE=$?
-         ;;
+    composerNormalize)
+        composerNormalize
+        SUITE_EXIT_CODE=$?
+        ;;
     composerUnused)
         composerUnused
         SUITE_EXIT_CODE=$?


### PR DESCRIPTION
The `composerNormalize` command in `runTests.sh` was set to always run in dry-run mode, which means that it will never fix things.

Also fix the indentation.

Followup to #2251