### PR TITLE
[DOCS] Update the TYPO3 version badges in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Example TYPO3 extension for code quality checks and automated tests
 
-[![TYPO3 V12](https://img.shields.io/badge/TYPO3-12-orange.svg)](https://get.typo3.org/version/12)
 [![TYPO3 V13](https://img.shields.io/badge/TYPO3-13-orange.svg)](https://get.typo3.org/version/13)
+[![TYPO3 V14](https://img.shields.io/badge/TYPO3-14-orange.svg)](https://get.typo3.org/version/14)
 [![License](https://img.shields.io/github/license/TYPO3BestPractices/tea)](https://packagist.org/packages/ttn/tea)
 [![GitHub CI status](https://github.com/TYPO3BestPractices/tea/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/TYPO3BestPractices/tea/actions)
 [![Coverage Status](https://coveralls.io/repos/github/TYPO3BestPractices/tea/badge.svg?branch=main)](https://coveralls.io/github/TYPO3BestPractices/tea?branch=main)


### PR DESCRIPTION
Drop 12LTS, add 14LTS.

Part of #2253