### PR TITLE
[TASK] Use PHP 8.5 by default in `runTests.sh`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -284,10 +284,10 @@ Options:
 
     -p <8.2|8.3|8.4|8.5>
         Specifies the PHP minor version to be used
-            - 8.2: (default) use PHP 8.2
+            - 8.2: use PHP 8.2
             - 8.3: use PHP 8.3
             - 8.4: use PHP 8.4
-            - 8.5: use PHP 8.5
+            - 8.5: (default) use PHP 8.5
 
     -e "<phpunit options>" (DEPRECATED).
         Only with -s functional|functionalDeprecated|unit|unitDeprecated|unitRandom
@@ -329,7 +329,7 @@ Options:
         Show this help.
 
 Examples:
-    # Run all core unit tests using PHP 8.2
+    # Run all core unit tests using PHP 8.5
     ./Build/Scripts/runTests.sh
     ./Build/Scripts/runTests.sh -s unit
 
@@ -470,7 +470,7 @@ TEST_SUITE="unit"
 CORE_VERSION="13.4"
 DBMS="sqlite"
 DBMS_VERSION=""
-PHP_VERSION="8.2"
+PHP_VERSION="8.5"
 PHP_XDEBUG_ON=0
 PHP_XDEBUG_PORT=9003
 PHPUNIT_RANDOM=""


### PR DESCRIPTION
This matches the latest changes to the Core `runTests.sh`: https://review.typo3.org/c/Packages/TYPO3.CMS/+/94800

We keep PHP 8.2 throught 8.4 as long as we support TYPO3 13LTS and 14LTS.