### PR TITLE
[TASK] Do not automatically add `#[DoesNotPerformAssertion]`

### DIFF
--- a/Build/rector/config.php
+++ b/Build/rector/config.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 use Ssch\TYPO3Rector\CodeQuality\General\ExtEmConfRector;
 use Ssch\TYPO3Rector\Configuration\Typo3Option;
@@ -55,4 +56,6 @@ return RectorConfig::configure()
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
     ])
     ->withSkip([
+        // This rule creates false positives as the TYPO3 testing framework always adds assertions.
+        AddDoesNotPerformAssertionToNonAssertingTestRector::class,
     ]);


### PR DESCRIPTION
The TYPO3 testing framework always has some assertions in its `tearDown()`, which Rector does not detect. So Rector should not automatically add the `#[DoesNotPerformAssertion]` attribute to tests that do not contain any assertions.