### PR TITLE
[TASK] Make Rector a direct development dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
 		"phpstan/phpstan-strict-rules": "2.0.12",
 		"phpunit/phpcov": "10.0.1",
 		"phpunit/phpunit": "11.5.56",
+		"rector/rector": "2.6.3",
 		"rector/type-perfect": "2.2.0",
 		"saschaegerer/phpstan-typo3": "2.2.0 || 3.1.0",
 		"seld/jsonlint": "1.12.1",


### PR DESCRIPTION
So far, `rector/rector` has been a transitive dependency
of the `ssch/typo3-rector` package. This allowed
updates of `rector/rector` to happen without us touching
the `composer.json`, and causing CI breakage.

In order to keep the specific version of `rector/rector`
under strict control, it now is a direct development
dependency with a pinned version.

```
composer req --dev rector/rector:2.6.3
```

Fixes #2285