### PR TITLE
[TASK] Allow deprecations in the functional tests

### DIFF
--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -12,7 +12,7 @@
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
     failOnAllIssues="true"
-    failOnDeprecation="true"
+    failOnDeprecation="false"
     failOnEmptyTestSuite="true"
     failOnNotice="true"
     failOnPhpunitDeprecation="true"


### PR DESCRIPTION
Validation of domain model properties has changed in TYPO3 V14, and the old way has been deprecated:
https://docs.typo3.org/permalink/changelog:deprecation-97559-1760453281

As there is currently no way to get the code working both in V13 and V14 without deprecations, deprecations in the functional tests now don't make the build fail anymore.

Part of #2253