### PR TITLE
[BUGFIX] Allow relative links in the BE module controller tests

### DIFF
--- a/Tests/Functional/Controller/BackendModuleControllerTest.php
+++ b/Tests/Functional/Controller/BackendModuleControllerTest.php
@@ -172,7 +172,7 @@ final class BackendModuleControllerTest extends FunctionalTestCase
         $html = $response->getBody()->__toString();
 
         self::assertStringContainsString(
-            htmlspecialchars('/typo3/record/edit?' . $expectedUrlQuery, ENT_QUOTES),
+            htmlspecialchars('typo3/record/edit?' . $expectedUrlQuery, ENT_QUOTES),
             $html,
         );
     }


### PR DESCRIPTION
TYPO3 V14 has switched Extbase actions links in the backend from absolute links to relative links by dropping the trailing slash.

Adapt the test to allow both variants.

Part of #2253