### PR TITLE
[BUGFIX] Do not check for natives types in class constants

### DIFF
--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -14,9 +14,12 @@ parameters:
     - ../../ext_localconf.php
 
   type_coverage:
-    return_type: 100
+    # Native types for class constants are only available in PHP >= 8.3.0:
+    # https://www.php.net/manual/en/language.oop5.constants.php
+    constant_type: 0
     param_type: 100
     property_type: 95
+    return_type: 100
 
   cognitive_complexity:
     class: 10


### PR DESCRIPTION
Native type declarations for PHP class constants were introduced in PHP 8.3.0. [1] As we currently support PHP >= 8.2, we need to configure PHPStan to not require native types for class constants.

Also sort the corresponding section of the PHPStan configuration file.

[1] https://www.php.net/manual/en/language.oop5.constants.php