### PR TITLE
[BUGFIX] Avoid changing autoload files when checking PSR conformity

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -440,7 +440,7 @@ phpstanGenerateBaseline() {
 }
 
 psrVerify() {
-    COMMAND="composer dumpautoload --optimize --strict-psr --no-plugins"
+    COMMAND="composer dumpautoload --optimize --strict-psr --no-plugins --dry-run"
     ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name psr-verify-${SUFFIX} ${IMAGE_PHP} ${COMMAND}
 }
 

--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,7 @@
 	},
 	"scripts": {
 		"check:composer:normalize": "@composer normalize --no-check-lock --dry-run",
-		"check:composer:psr-verify": "@composer dumpautoload --optimize --strict-psr --no-plugins",
+		"check:composer:psr-verify": "@composer dumpautoload --optimize --strict-psr --no-plugins --dry-run",
 		"check:composer:unused": "composer-unused --configuration=Build/composer-unused/composer-unused.php",
 		"check:coverage": [
 			"@check:coverage:unit",


### PR DESCRIPTION
The verifyPsr script (both in runTests.sh and as a composer script) modified the autoload files in a way that subsequent script calls like e.g. unit failed. This violates the expectation of check scripts not modifying test results.
To fix the issue, an additional composer install call has been introduced in both places. It's quiet to avoid cluttering script output.

Fixes #1948