### PR TITLE
[TASK] Allow deprecations for individual tests

### DIFF
--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -12,7 +12,7 @@
     displayDetailsOnTestsThatTriggerNotices="true"
     displayDetailsOnTestsThatTriggerWarnings="true"
     failOnAllIssues="true"
-    failOnDeprecation="false"
+    failOnDeprecation="true"
     failOnEmptyTestSuite="true"
     failOnNotice="true"
     failOnPhpunitDeprecation="true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Add support for TYPO3 14LTS (#2254, #2266)
+- Add support for TYPO3 14LTS (#2254, #2266, #2301, #2302, #2308)
 - Add a dedicated weekly CI workflow (#1903)
 
 ### Changed

--- a/Tests/Functional/Controller/BackendModuleControllerTest.php
+++ b/Tests/Functional/Controller/BackendModuleControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TTN\Tea\Tests\Functional\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
 use TTN\Tea\Controller\BackendModuleController;
@@ -46,6 +47,7 @@ final class BackendModuleControllerTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function indexListsTeasFromMultiplePids(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/BackendModuleController/TeasForIndex.csv');
@@ -145,6 +147,7 @@ final class BackendModuleControllerTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function indexLinksTeaValuesToEditForm(): void
     {
         $token = $this->get(HashService::class)->hmac(

--- a/Tests/Functional/Controller/FrontEndEditorControllerTest.php
+++ b/Tests/Functional/Controller/FrontEndEditorControllerTest.php
@@ -6,6 +6,7 @@ namespace TTN\Tea\Tests\Functional\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
 use TTN\Tea\Controller\FrontEndEditorController;
@@ -58,6 +59,7 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function indexActionForNoLoggedInUserRendersErrorMessage(): void
     {
         $request = (new InternalRequest())->withPageId(self::UID_OF_PAGE);
@@ -71,6 +73,7 @@ final class FrontEndEditorControllerTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function indexActionForLoggedInUserRendersTeaOwnedByTheLoggedInUser(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/FrontEndEditorController/TeaAssignedToLoggedInUser.csv');

--- a/Tests/Functional/Controller/TeaControllerTest.php
+++ b/Tests/Functional/Controller/TeaControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TTN\Tea\Tests\Functional\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TTN\Tea\Controller\TeaController;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
@@ -50,6 +51,7 @@ final class TeaControllerTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function indexActionShowsMessageWhenNoTeasAreAvailable(): void
     {
         $request = (new InternalRequest())->withPageId(1);
@@ -70,6 +72,7 @@ final class TeaControllerTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function indexActionRendersAllAvailableTeasOnStoragePage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/TeaController/Teas.csv');

--- a/Tests/Functional/Domain/Model/TeaTest.php
+++ b/Tests/Functional/Domain/Model/TeaTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TTN\Tea\Tests\Functional\Domain\Model;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TTN\Tea\Domain\Model\Tea;
 use TYPO3\CMS\Extbase\Validation\Validator\ConjunctionValidator;
@@ -31,6 +32,7 @@ final class TeaTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function titleWithMaximumLengthPassesValidation(): void
     {
         $this->subject->setTitle(str_repeat('p', 255));
@@ -41,6 +43,7 @@ final class TeaTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function titleLongerThanMaximumLengthDoesNotPassValidation(): void
     {
         $this->subject->setTitle(str_repeat('p', 256));
@@ -51,6 +54,7 @@ final class TeaTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function emptyTitleDoesNotPassValidation(): void
     {
         $this->subject->setTitle('');
@@ -61,6 +65,7 @@ final class TeaTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function descriptionWithMaximumLengthPassesValidation(): void
     {
         $this->subject->setDescription(str_repeat('d', 2000));
@@ -71,6 +76,7 @@ final class TeaTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function descriptionLongerThanMaximumLengthDoesNotPassValidation(): void
     {
         $this->subject->setDescription(str_repeat('d', 2001));

--- a/Tests/Functional/Domain/Repository/TeaRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/TeaRepositoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TTN\Tea\Tests\Functional\Domain\Repository;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TTN\Tea\Domain\Model\Tea;
 use TTN\Tea\Domain\Repository\TeaRepository;
@@ -39,6 +40,7 @@ final class TeaRepositoryTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function findAllForNoRecordsReturnsEmptyQueryResult(): void
     {
         $result = $this->subject->findAll();


### PR DESCRIPTION
The switch to not fail on deprecations in the PHPUnit configuration file does not keep the tests from
returning a failure exit code on deprecattions.

So revert that setting in the PHPUnit configuration file and instead allow deprecations in all tests that trigger a deprecation notice (i.e., all tests that trigger model validations that are deprecated in TYPO3 V14).

Followup to #2301

Part of #2253