### PR TITLE
[TASK] Adapt BE functional tests to V14 URL generation

### DIFF
--- a/Build/phpstan/TYPO3_13.4/phpstan-baseline.neon
+++ b/Build/phpstan/TYPO3_13.4/phpstan-baseline.neon
@@ -11,3 +11,15 @@ parameters:
 			identifier: missingType.generics
 			count: 1
 			path: ../../../Classes/Domain/Repository/TeaRepository.php
+
+		-
+			rawMessage: Access to constant SHA3_256 on an unknown class TYPO3\CMS\Core\Crypto\HashAlgo.
+			identifier: class.notFound
+			count: 1
+			path: ../../../Tests/Functional/Controller/BackendModuleControllerTest.php
+
+		-
+			rawMessage: 'Method TYPO3\CMS\Core\Crypto\HashService::hmac() invoked with 3 parameters, 2 required.'
+			identifier: arguments.count
+			count: 1
+			path: ../../../Tests/Functional/Controller/BackendModuleControllerTest.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Add support for TYPO3 14LTS (#2254, #2266, #2301, #2302, #2304, #2308)
+- Add support for TYPO3 14LTS (#2254, #2266, #2301, #2302, #2304, #2308, #2309)
 - Add a dedicated weekly CI workflow (#1903)
 
 ### Changed

--- a/Tests/Functional/Controller/BackendModuleControllerTest.php
+++ b/Tests/Functional/Controller/BackendModuleControllerTest.php
@@ -12,10 +12,12 @@ use TTN\Tea\Controller\BackendModuleController;
 use TYPO3\CMS\Backend\Routing\Route;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Crypto\HashAlgo;
 use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\FormProtection\AbstractFormProtection;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -150,10 +152,20 @@ final class BackendModuleControllerTest extends FunctionalTestCase
     #[IgnoreDeprecations]
     public function indexLinksTeaValuesToEditForm(): void
     {
-        $token = $this->get(HashService::class)->hmac(
-            'routerecord_edit' . self::FORM_PROTECTION_SESSION_TOKEN,
-            AbstractFormProtection::class,
-        );
+        if (((new Typo3Version())->getMajorVersion() >= 14)) {
+            $token = $this->get(HashService::class)->hmac(
+                'routerecord_edit' . self::FORM_PROTECTION_SESSION_TOKEN,
+                AbstractFormProtection::class,
+                HashAlgo::SHA3_256,
+            );
+            $moduleUrlParameter = '&module=';
+        } else {
+            $moduleUrlParameter = '';
+            $token = $this->get(HashService::class)->hmac(
+                'routerecord_edit' . self::FORM_PROTECTION_SESSION_TOKEN,
+                AbstractFormProtection::class,
+            );
+        }
 
         $expectedUrlQuery = http_build_query([
             'token' => $token,
@@ -162,7 +174,7 @@ final class BackendModuleControllerTest extends FunctionalTestCase
                     1 => 'edit',
                 ],
             ],
-        ]) . '&returnUrl=typo3/module/tea/index/BackendModule/index';
+        ]) . $moduleUrlParameter . '&returnUrl=typo3/module/tea/index/BackendModule/index';
 
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/BackendModuleController/TeaForIndex.csv');
 


### PR DESCRIPTION
In TYPO3 V14, the form protection tokens now are hashed with the more secure SHA3_256 algorithm.

Also, Extbase BE action links now by default contain a `module` parameter (event if it is empty).

Adapt the tests accordingly to the V13 and V14 cases.

Part of #2253