### PR TITLE
[TASK] Ignore deprecations in V14 in yet another test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Add support for TYPO3 14LTS (#2254, #2266, #2301, #2302, #2304, #2308, #2309)
+- Add support for TYPO3 14LTS (#2254, #2266, #2301, #2302, #2304, #2308, #2309,
+  #2310)
 - Add a dedicated weekly CI workflow (#1903)
 
 ### Changed

--- a/Tests/Functional/Controller/BackendModuleControllerTest.php
+++ b/Tests/Functional/Controller/BackendModuleControllerTest.php
@@ -67,6 +67,7 @@ final class BackendModuleControllerTest extends FunctionalTestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function indexProvidesCaptionForListing(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/Database/BackendModuleController/TeaForIndex.csv');


### PR DESCRIPTION
With this last atttribute, the functional tests in V14 are not failing due to deprecations anymore.

Followup to #2308
Part of #2253