### PR TITLE
[TASK] Inline more Fluid viewhelpers in the `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -53,7 +53,7 @@ indent_style = tab
 max_line_length = 80
 
 [*.{htm,html}]
-ij_html_add_new_line_before_tags = body,div,p,form,h1,h2,h3
+ij_html_add_new_line_before_tags = body,div,form,h1,h2,h3,p
 ij_html_align_attributes = true
 ij_html_align_text = false
 ij_html_attribute_wrap = normal
@@ -63,7 +63,7 @@ ij_html_do_not_align_children_of_min_lines = 0
 ij_html_do_not_break_if_inline_tags = title,h1,h2,h3,h4,h5,h6,p
 ij_html_do_not_indent_children_of_tags =
 ij_html_enforce_quotes = false
-ij_html_inline_tags = a,abbr,acronym,b,basefont,bdo,big,br,cite,cite,code,dfn,em,font,i,img,input,kbd,label,q,s,samp,select,small,span,strike,strong,sub,sup,textarea,tt,u,var,f:translate,f:format.number
+ij_html_inline_tags = a,abbr,acronym,b,basefont,bdo,big,br,cite,code,dfn,em,font,i,img,input,kbd,label,q,s,samp,select,small,span,strike,strong,sub,sup,textarea,tt,u,var,be:link,be:link.editRecord,be:link.newRecord,be:moduleLink,f:ceil,f:count,f:first,f:floor,f:format.case,f:format.htmlspecialchars,f:format.number,f:format.printf,f:format.raw,f:format.stripTags,f:format.trim,f:format.urlencode,f:image,f:last,f:link.action,f:link.email,f:link.external,f:link.file,f:link.page,f:link.typolink,f:max,f:replace,f:round,f:spaceless,f:translate
 ij_html_keep_blank_lines = 2
 ij_html_keep_indents_on_empty_lines = false
 ij_html_keep_line_breaks = true


### PR DESCRIPTION
Mark some Fluid viewhelpers that will result in inline HTML tags as inline.